### PR TITLE
Small fixes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -75,7 +75,7 @@ jobs:
         path: code-coverage-results.md
 
   comment:
-    name: Code Coverage PR Commit
+    name: Code Coverage PR Comment
     needs: coverage
     runs-on: [ubuntu-20.04, self-hosted]
     permissions:

--- a/README.md
+++ b/README.md
@@ -32,29 +32,50 @@ void printBatteryLevel(const char *data, size_t size)
     std::cout << "Battery Level: " << int(result->level()) << "%" << std::endl;
 }
 ```
+If you need only a string representation of parsed data you can use the following code example:
+```c++
+#include "blevalueparser.h"
+
+[...]
+
+void printParsed(bvp::CharacteristicType chType, const char *data, size_t size)
+{
+    bvp::BLEValueParser bleValueParser;
+    auto result = bleValueParser.make_value(chType, data, size);
+    if (!result->isValid())
+    {
+        std::cout << "Invalid data" << std::endl;
+        return;
+    }
+
+    std::cout << "Parsed Data: " << result->toString() << std::endl;
+}
+```
+
 
 # Build Tests and Example
 To build you'll need at least CMake and Qt5 or Qt6.
+
+NB: If CMake doesn't find installed Qt then you can explicitly specify the path like this:
+```sh
+# for Qt5
+cmake -B ./build -DCMAKE_PREFIX_PATH=${HOME}/Qt/5.15.2/clang_64/lib/cmake
+```
+```sh
+# for Qt6
+cmake -B ./build -DCMAKE_PREFIX_PATH=${HOME}/Qt/6.2.4/macos/lib/cmake
+```
 
 ## macOS
 
 ### Console
 1. Generate project:
-  * To build with Qt5 on Apple silicon:
 ```sh
-cmake -B ./build -DCMAKE_PREFIX_PATH=${HOME}/Qt/5.15.2/clang_64/lib/cmake
+cmake -B ./build
 ```
-  * To build with Qt5 on Intel:
+or you can use generator for Ninja build system:
 ```sh
-cmake -B ./build -DCMAKE_PREFIX_PATH=${HOME}/Qt/5.15.2/clang_64/lib/cmake
-```
-  * To build with Qt6:
-```sh
-cmake -B ./build -DCMAKE_PREFIX_PATH=${HOME}/Qt/6.2.4/macos/lib/cmake
-```
-  Also you can use generator for Ninja build system:
-```sh
-cmake -G Ninja -B ./build -DCMAKE_PREFIX_PATH=${HOME}/Qt/6.2.4/macos/lib/cmake
+cmake -G Ninja -B ./build
 ```
 2. Build:
 ```sh
@@ -63,17 +84,8 @@ cmake --build ./build
 
 ### Xcode
 1. Generate project:
-  * To build with Qt5 on Apple silicon:
 ```sh
-cmake -G Xcode -B ./build -DCMAKE_PREFIX_PATH=${HOME}/Qt/5.15.2/clang_64/lib/cmake
-```
-  * To build with Qt5 on Intel:
-```sh
-cmake -G Xcode -B ./build -DCMAKE_PREFIX_PATH=${HOME}/Qt/5.15.2/clang_64/lib/cmake
-```
-  * To build with Qt6:
-```sh
-cmake -G Xcode -B ./build -DCMAKE_PREFIX_PATH=${HOME}/Qt/6.2.4/macos/lib/cmake
+cmake -G Xcode -B ./build
 ```
 2. Open generated project in Xcode, select target, build.
 
@@ -90,8 +102,17 @@ cmake --build ./build
 You can also use Ninja build system and QtCreator on Linux.
 
 # Tests
-The functionality of library is covered by tests. The GoogleTest framework is used. The test coverage for the demo application isn't implemented.
+The functionality of library is covered by tests. The GoogleTest framework is used. At the moment test coverage for the demo application isn't implemented.
+
+You can skip tests build on CMake configuration:
+```sh
+cmake -B ./build -DBUILD_TESTS=OFF
+```
 
 # Examples
 Currently there is only one example in the project. This demo application uses Qt framework.
 
+You can skip examples build on CMake configuration:
+```sh
+cmake -B ./build -DBUILD_EXAMPLES=OFF
+```

--- a/tests/heartratemeasurementtest.cpp
+++ b/tests/heartratemeasurementtest.cpp
@@ -344,7 +344,6 @@ TEST_F(HeartRateMeasurementTest, ToString)
 {
     constexpr char flags = 0b00011001;
     constexpr char data[] = { flags, '\xAA', '\x01', '\xBB', '\x01', '\xA1', '\x01', '\xA2', '\x01', '\xA3', '\x01', '\xA4', '\x01', '\xA5', '\x01', '\xA6', '\x01', '\xA7', '\x01' };
-    BLEValueParser bleValueParser;
     auto result = bleValueParser.make_value(CharacteristicType::HeartRateMeasurement,
                                             data, sizeof(data));
     EXPECT_NE(nullptr, result);

--- a/tests/hexstringtest.cpp
+++ b/tests/hexstringtest.cpp
@@ -37,7 +37,6 @@ TEST_F(HexStringTest, Empty)
 TEST_F(HexStringTest, ToString)
 {
     constexpr char data[] = { '\x01', '\x02', '\x03', '\x0D', '\x0E', '\x0F' };
-    BLEValueParser bleValueParser;
     auto result = bleValueParser.make_value(CharacteristicType::SystemID,
                                             data, sizeof(data));
     EXPECT_NE(nullptr, result);
@@ -48,7 +47,6 @@ TEST_F(HexStringTest, ToString)
 TEST_F(HexStringTest, Configuration)
 {
     constexpr char data[] = { '\x01', '\x02', '\x03', '\x0D', '\x0E', '\x0F' };
-    BLEValueParser bleValueParser;
     bleValueParser.setStringPrefix("<< ");
     bleValueParser.setStringSuffix(" >>");
     bleValueParser.setHexPrefix("hex> ");

--- a/tests/localtimeinformationtest.cpp
+++ b/tests/localtimeinformationtest.cpp
@@ -51,7 +51,6 @@ TEST_F(LocalTimeInformationTest, TZ0_DST1h)
 TEST_F(LocalTimeInformationTest, ToString)
 {
     constexpr char data[] = { char(-42), '\x08' };
-    BLEValueParser bleValueParser;
     auto result = bleValueParser.make_value(CharacteristicType::LocalTimeInformation,
                                             data, sizeof(data));
     EXPECT_NE(nullptr, result);

--- a/tests/pnpidtest.cpp
+++ b/tests/pnpidtest.cpp
@@ -79,7 +79,6 @@ TEST_F(PnPIDTest, TooLong)
 TEST_F(PnPIDTest, ToString)
 {
     constexpr char data[] = { '\x02', '\x12', '\x00', '\x23', '\x01', '\xBC', '\xAA' };
-    BLEValueParser bleValueParser;
     auto result = bleValueParser.make_value(CharacteristicType::PnPID,
                                             data, sizeof(data));
     EXPECT_NE(nullptr, result);

--- a/tests/textstringtest.cpp
+++ b/tests/textstringtest.cpp
@@ -37,7 +37,6 @@ TEST_F(TextStringTest, Empty)
 TEST_F(TextStringTest, ToString)
 {
     constexpr char data[] = { 'a', 'B', 'c', 'X', 'y', 'Z' };
-    BLEValueParser bleValueParser;
     auto result = bleValueParser.make_value(CharacteristicType::ModelNumberString,
                                             data, sizeof(data));
     EXPECT_NE(nullptr, result);


### PR DESCRIPTION
- added: example of using string representation of analyzed data without type specialization at compile time
- added: information in `README.md` about options `BUILD_TESTS` and `BUILD_EXAMPLES` to skip unused build parts
- removed: obsolete information in `README.md`
- fixed: obsolete usage of local objects in tests code
- fixed: typo in workflow job name