### PR TITLE
Fixed issues on Boot2Qt

### DIFF
--- a/examples/qt/blemanager.cpp
+++ b/examples/qt/blemanager.cpp
@@ -11,9 +11,10 @@
 namespace
 {
 constexpr int discoveryTimeout = 10000;
-constexpr const char enableNotification[2] = { '\x01', '\x00' };
-constexpr const char disableNotification[2] = { '\x00', '\x00' };
 }
+
+const QByteArray BLEManager::s_enableNotification{QByteArray::fromHex("0100")};
+const QByteArray BLEManager::s_disableNotification{QByteArray::fromHex("0000")};
 
 BLEManager::BLEManager(QObject *parent) : QObject{parent}
 {
@@ -207,7 +208,7 @@ bool BLEManager::isSubscribed() const
     qDebug() << __FUNCTION__;
     if (m_notificationDescriptor.isValid() &&
         m_service &&
-        m_notificationDescriptor.value() == enableNotification)
+        m_notificationDescriptor.value() == s_enableNotification)
     {
         return true;
     }
@@ -778,9 +779,7 @@ void BLEManager::connectToCharacteristic(int index)
     }
     auto properties = m_characteristic->properties();
     qDebug() << "properties:" << properties;
-    //
-    QObject *object = m_availableCharacteristics.at(index);
-    m_characteristicName = qobject_cast<BleCharacteristicInfo *>(object)->description();
+    m_characteristicName = bleCharacteristicInfo->description();
     qDebug() << m_characteristicName;
     m_characteristicValue = m_characteristic->value();
     qDebug() << m_characteristicValue;
@@ -797,7 +796,7 @@ void BLEManager::unsubscribeFromNotifications()
     qDebug() << __FUNCTION__;
     if (isSubscribed())
     {
-        m_service->writeDescriptor(m_notificationDescriptor, disableNotification);
+        m_service->writeDescriptor(m_notificationDescriptor, s_disableNotification);
     }
 }
 
@@ -828,7 +827,7 @@ void BLEManager::subscribeToNotifications()
             descriptor.type() == QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration)
         {
             m_notificationDescriptor = descriptor;
-            m_service->writeDescriptor(m_notificationDescriptor, enableNotification);
+            m_service->writeDescriptor(m_notificationDescriptor, s_enableNotification);
             //emit isSubscribedUpdated();
             break;
         }
@@ -849,7 +848,7 @@ void BLEManager::descriptorWritten(const QLowEnergyDescriptor &info, const QByte
     qDebug() << __FUNCTION__;
     if (info.isValid() &&
         info == m_notificationDescriptor &&
-        value == enableNotification || value == disableNotification)
+        value == s_enableNotification || value == s_disableNotification)
     {
         emit isSubscribedUpdated();
     }

--- a/examples/qt/blemanager.h
+++ b/examples/qt/blemanager.h
@@ -134,6 +134,9 @@ private slots:
     void descriptorWritten(const QLowEnergyDescriptor &info, const QByteArray &value);
 
 private:
+    static const QByteArray s_enableNotification;
+    static const QByteArray s_disableNotification;
+
     bvp::BLEValueParser m_bleValueParser;
 
     mutable QString m_statusString;

--- a/examples/qt/qml/CustomButton.qml
+++ b/examples/qt/qml/CustomButton.qml
@@ -10,13 +10,50 @@ Button {
 
     property bool square: false
 
-    function adjustSize() {
-        if (square) {
-            padding = UISettings.halfSpacer
-            width = height
+    Timer {
+        id: timer
+    }
+
+    function setHighlighted(highlighted) {
+        if (highlighted) {
+            if (control.enabled) {
+                bg.color = UISettings.colorHighlight
+                bg.border.width = UISettings.doubleLine
+            }
         } else {
-            verticalPadding = UISettings.normalSpacer
-            horizontalPadding = UISettings.doubleSpacer
+            bg.color = UISettings.colorBg
+            bg.border.width = UISettings.normalLine
+        }
+    }
+
+    function adjustSize() {
+        // Workaround: when software renderer is used, we get an outdated width/height/etc if we request it immediately
+        runDelayed(timer, UISettings.adjustDelay, function() {
+            if (square) {
+                padding = UISettings.halfSpacer
+                implicitWidth = implicitHeight
+            } else {
+                verticalPadding = UISettings.normalSpacer
+                horizontalPadding = UISettings.doubleSpacer
+            }
+            setHighlighted(hovered)
+        })
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        hoverEnabled: true
+
+        onClicked: {
+            control.clicked()
+        }
+
+        onEntered: {
+            setHighlighted(true)
+        }
+
+        onExited: {
+            setHighlighted(false)
         }
     }
 
@@ -34,10 +71,11 @@ Button {
     }
 
     background: Rectangle {
+        id: bg
         opacity: enabled ? 1.0 : 0.5
-        color: control.hovered && control.enabled ? UISettings.colorHighlight : UISettings.colorBg
+        color: UISettings.colorBg
         border.color: UISettings.colorLine
-        border.width: control.hovered && control.enabled ? UISettings.doubleLine : UISettings.normalLine
+        border.width: UISettings.normalLine
         radius: UISettings.cornerRadius
     }
 

--- a/examples/qt/qml/HorizontalBusyIndicator.qml
+++ b/examples/qt/qml/HorizontalBusyIndicator.qml
@@ -7,9 +7,16 @@ Item {
     property bool running: false
     property color color: UISettings.colorLine
 
+    Timer {
+        id: timer
+    }
+
     function adjustSize() {
-        implicitHeight = UISettings.doubleLine
-        busyAnimation.restart()
+        // Workaround: when software renderer is used, we get an outdated width/height/etc if we request it immediately
+        runDelayed(timer, UISettings.adjustDelay, function() {
+            implicitHeight = UISettings.doubleLine
+            busyAnimation.restart()
+        })
     }
 
     Component.onCompleted: {

--- a/examples/qt/qml/ListItemLayout.qml
+++ b/examples/qt/qml/ListItemLayout.qml
@@ -4,10 +4,17 @@ import QtQuick.Layouts 1.14
 
 ColumnLayout {
     id: itemLayout
-    width: parent.width
+
+    Timer {
+        id: timer
+    }
 
     function adjustSize() {
-        parent.height = height
+        // Workaround: when software renderer is used, we get an outdated width/height/etc if we request it immediately
+        runDelayed(timer, UISettings.adjustDelay, function() {
+            width = parent.width
+            parent.height = height
+        })
     }
 
     Component.onCompleted: {

--- a/examples/qt/qml/ListItemSeparator.qml
+++ b/examples/qt/qml/ListItemSeparator.qml
@@ -4,9 +4,16 @@ import QtQuick 2.14
 Rectangle {
     color: index === 0 ? "transparent" : UISettings.colorSeparator
 
+    Timer {
+        id: timer
+    }
+
     function adjustSize() {
-        implicitWidth = parent.width
-        implicitHeight = UISettings.normalLine
+        // Workaround: when software renderer is used, we get an outdated width/height/etc if we request it immediately
+        runDelayed(timer, UISettings.adjustDelay, function() {
+            implicitWidth = parent.width
+            implicitHeight = UISettings.normalLine
+        })
     }
 
     Component.onCompleted: {

--- a/examples/qt/qml/UISettings.qml
+++ b/examples/qt/qml/UISettings.qml
@@ -29,4 +29,6 @@ Item {
 
     readonly property int normalLine: fontSizeNormal / 10.0
     readonly property int doubleLine: normalLine * 2
+
+    readonly property int adjustDelay: 0
 }

--- a/examples/qt/qml/main.qml
+++ b/examples/qt/qml/main.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.14
 import QtQuick.Window 2.14
 import QtQuick.Controls 2.14
-import QtQuick.VirtualKeyboard 2.14
 import dev.eisaev.blemanager 1.0
 
 
@@ -34,6 +33,13 @@ ApplicationWindow {
 
     onHeightChanged: {
         sizeChanged()
+    }
+
+    function runDelayed(timer, delayMs, cb) {
+        timer.interval = delayMs;
+        timer.triggered.connect(cb);
+        timer.repeat = false;
+        timer.start();
     }
 
     function goBack() {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,3 +35,5 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
 
 enable_testing()
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
+
+install(TARGETS ${PROJECT_NAME})


### PR DESCRIPTION
- fixed: `bvptest` isn't deployed on the device when running in QtCreator
- fixed: style of `CustomButton` doesn't change on hover
- fixed: when software renderer is used, we get an outdated width/height/etc of QML component if we request it immediately
- fixed: unable subscribe for notifications on Linux based systems
- removed: unused `QtQuick.VirtualKeyboard` dependency