### PR TITLE
Implementation of Body Composition Service v1.0.0

### DIFF
--- a/examples/qt/blemanager.h
+++ b/examples/qt/blemanager.h
@@ -38,6 +38,7 @@ class BLEManager : public QObject
     Q_PROPERTY(QVariant characteristicValueParsed READ characteristicValueParsed NOTIFY characteristicValueUpdated)
     Q_PROPERTY(QVariant characteristicIsRead READ characteristicIsRead CONSTANT)
     Q_PROPERTY(QVariant characteristicIsNotify READ characteristicIsNotify CONSTANT)
+    Q_PROPERTY(QVariant characteristicIsIndicate READ characteristicIsIndicate CONSTANT)
 
 public:
     explicit BLEManager(QObject *parent = nullptr);
@@ -63,6 +64,7 @@ public:
     QVariant characteristicValueParsed() const;
     QVariant characteristicIsRead() const;
     QVariant characteristicIsNotify() const;
+    QVariant characteristicIsIndicate() const;
 
 public slots:
     void startDevicesDiscovery();
@@ -146,6 +148,8 @@ private:
     QBluetoothDeviceDiscoveryAgent *m_discoveryAgent{nullptr};
     QObjectList m_availableDevices;
 
+    std::unique_ptr<bvp::PnPID> m_devicePnPID{nullptr};
+
     QLowEnergyController *m_controller{nullptr};
     QObjectList m_availableServices;
 
@@ -157,5 +161,6 @@ private:
     QByteArray m_characteristicValue;
     QLowEnergyDescriptor m_notificationDescriptor;
 
+    bvp::CharacteristicType fixupCharacteristicType(bvp::CharacteristicType characteristicType) const;
     void updateServiceState(QLowEnergyService::ServiceState newState);
 };

--- a/examples/qt/qml/Characteristic.qml
+++ b/examples/qt/qml/Characteristic.qml
@@ -68,7 +68,7 @@ Item {
             }
 
             CustomButton {
-                visible: BLEManagerSingleton.characteristicIsNotify
+                visible: BLEManagerSingleton.characteristicIsNotify || BLEManagerSingleton.characteristicIsIndicate
                 enabled: isDeviceConnected && !isSubscribed
                 text: qsTr("Subscribe")
                 onClicked: BLEManagerSingleton.subscribeToNotifications()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,8 +16,12 @@ FetchContent_MakeAvailable(gtest)
 set(TEST_SOURCES
     tests.cpp
     batteryleveltest.cpp
+    bodycompositionfeaturetest.cpp
+    bodycompositionmeasurementmibfstest.cpp
+    bodycompositionmeasurementtest.cpp
     bodysensorlocationtest.cpp
     currenttimetest.cpp
+    datetimetest.cpp
     heartratemeasurementtest.cpp
     hexstringtest.cpp
     internalparsertest.cpp
@@ -25,6 +29,7 @@ set(TEST_SOURCES
     pnpidtest.cpp
     textstringtest.cpp
     unsupportedtest.cpp
+    userindextest.cpp
 )
 
 add_executable(${PROJECT_NAME} ${TEST_SOURCES})

--- a/tests/batteryleveltest.cpp
+++ b/tests/batteryleveltest.cpp
@@ -23,6 +23,7 @@ TEST_F(BatteryLevelTest, Zero)
     constexpr char data[] = { '\x00' };
 
     auto result = bleValueParser.make_value<BatteryLevel>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(0, result->level());
 
@@ -37,6 +38,7 @@ TEST_F(BatteryLevelTest, Full)
     constexpr char data[] = { '\x64' };
 
     auto result = bleValueParser.make_value<BatteryLevel>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(100, result->level());
 
@@ -51,6 +53,7 @@ TEST_F(BatteryLevelTest, Unreal)
     constexpr char data[] = { '\x92' };
 
     auto result = bleValueParser.make_value<BatteryLevel>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_FALSE(result->isValid());
 
     auto btSpecObj = result->getBtSpecObject();

--- a/tests/bodycompositionfeaturetest.cpp
+++ b/tests/bodycompositionfeaturetest.cpp
@@ -1,0 +1,343 @@
+#include "gtest/gtest.h"
+
+#include "blevalueparser.h"
+
+#define C(x) static_cast<char>(x)
+
+
+namespace bvp
+{
+
+class BodyCompositionFeatureTest : public testing::Test
+{
+protected:
+    explicit BodyCompositionFeatureTest() {}
+    virtual ~BodyCompositionFeatureTest() {}
+
+    BLEValueParser bleValueParser;
+
+//    virtual void SetUp() {}
+//    virtual void TearDown() {}
+};
+
+TEST_F(BodyCompositionFeatureTest, FeaturesAll_WeightResNotSpec_HeightResNotSpec_ReservedEven)
+{
+    //                             RRRRRRRR       RRRRRRHH       HWWWWFFF       FFFFFFFF
+    constexpr char flags[] = { C(0b10101010), C(0b10101000), C(0b00000111), C(0b11111111) };
+    constexpr char data[] = { flags[3], flags[2], flags[1], flags[0] };
+
+    auto result = bleValueParser.make_value<BodyCompositionFeature>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_TRUE(result->isTimeStampSupported());
+    EXPECT_TRUE(result->isMultipleUsersSupported());
+    EXPECT_TRUE(result->isBasalMetabolismSupported());
+    EXPECT_TRUE(result->isMusclePercentageSupported());
+    EXPECT_TRUE(result->isMuscleMassSupported());
+    EXPECT_TRUE(result->isFatFreeMassSupported());
+    EXPECT_TRUE(result->isSoftLeanMassSupported());
+    EXPECT_TRUE(result->isBodyWaterMassSupported());
+    EXPECT_TRUE(result->isImpedanceSupported());
+    EXPECT_TRUE(result->isWeightSupported());
+    EXPECT_TRUE(result->isHeightSupported());
+    EXPECT_EQ(0, result->weightResolution());
+    EXPECT_EQ(0, result->heightResolution());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(2863138815, btSpecObj.flags);
+
+    EXPECT_EQ("Features: { TimeStamp MultipleUsers BasalMetabolism MusclePercentage MuscleMass FatFreeMass SoftLeanMass BodyWaterMass Impedance Weight Height }, WeightResolution: 0kg, HeightResolution: 0m", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_EQ(0, result->weightResolution());
+    EXPECT_EQ(0, result->heightResolution());
+    EXPECT_EQ("Features: { TimeStamp MultipleUsers BasalMetabolism MusclePercentage MuscleMass FatFreeMass SoftLeanMass BodyWaterMass Impedance Weight Height }, WeightResolution: 0lb, HeightResolution: 0in", result->toString());
+}
+
+TEST_F(BodyCompositionFeatureTest, FeaturesNone_WeightRes0500_HeightRes0010_ReservedOdd)
+{
+    //                             RRRRRRRR       RRRRRRHH       HWWWWFFF       FFFFFFFF
+    constexpr char flags[] = { C(0b01010101), C(0b01010100), C(0b10001000), C(0b00000000) };
+    constexpr char data[] = { flags[3], flags[2], flags[1], flags[0] };
+
+    auto result = bleValueParser.make_value<BodyCompositionFeature>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isTimeStampSupported());
+    EXPECT_FALSE(result->isMultipleUsersSupported());
+    EXPECT_FALSE(result->isBasalMetabolismSupported());
+    EXPECT_FALSE(result->isMusclePercentageSupported());
+    EXPECT_FALSE(result->isMuscleMassSupported());
+    EXPECT_FALSE(result->isFatFreeMassSupported());
+    EXPECT_FALSE(result->isSoftLeanMassSupported());
+    EXPECT_FALSE(result->isBodyWaterMassSupported());
+    EXPECT_FALSE(result->isImpedanceSupported());
+    EXPECT_FALSE(result->isWeightSupported());
+    EXPECT_FALSE(result->isHeightSupported());
+    EXPECT_EQ(500, result->weightResolution());
+    EXPECT_EQ(10, result->heightResolution());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(1431603200, btSpecObj.flags);
+
+    EXPECT_EQ("Features: { }", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_EQ(1000, result->weightResolution());
+    EXPECT_EQ(1000, result->heightResolution());
+    EXPECT_EQ("Features: { }", result->toString());
+}
+
+TEST_F(BodyCompositionFeatureTest, FeaturesEven_WeightRes0200_HeightRes0005_ReservedAll)
+{
+    //                             RRRRRRRR       RRRRRRHH       HWWWWFFF       FFFFFFFF
+    constexpr char flags[] = { C(0b11111111), C(0b11111101), C(0b00010010), C(0b10101010) };
+    constexpr char data[] = { flags[3], flags[2], flags[1], flags[0] };
+
+    auto result = bleValueParser.make_value<BodyCompositionFeature>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isTimeStampSupported());
+    EXPECT_TRUE(result->isMultipleUsersSupported());
+    EXPECT_FALSE(result->isBasalMetabolismSupported());
+    EXPECT_TRUE(result->isMusclePercentageSupported());
+    EXPECT_FALSE(result->isMuscleMassSupported());
+    EXPECT_TRUE(result->isFatFreeMassSupported());
+    EXPECT_FALSE(result->isSoftLeanMassSupported());
+    EXPECT_TRUE(result->isBodyWaterMassSupported());
+    EXPECT_FALSE(result->isImpedanceSupported());
+    EXPECT_TRUE(result->isWeightSupported());
+    EXPECT_FALSE(result->isHeightSupported());
+    EXPECT_EQ(200, result->weightResolution());
+    EXPECT_EQ(5, result->heightResolution());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(4294775466, btSpecObj.flags);
+
+    EXPECT_EQ("Features: { MultipleUsers MusclePercentage FatFreeMass BodyWaterMass Weight }, WeightResolution: 0.2kg", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_EQ(500, result->weightResolution());
+    EXPECT_EQ(500, result->heightResolution());
+    EXPECT_EQ("Features: { MultipleUsers MusclePercentage FatFreeMass BodyWaterMass Weight }, WeightResolution: 0.5lb", result->toString());
+}
+
+TEST_F(BodyCompositionFeatureTest, FeaturesOdd_WeightRes0100_HeightRes0001_ReservedNone)
+{
+    //                             RRRRRRRR       RRRRRRHH       HWWWWFFF       FFFFFFFF
+    constexpr char flags[] = { C(0b00000000), C(0b00000001), C(0b10011101), C(0b01010101) };
+    constexpr char data[] = { flags[3], flags[2], flags[1], flags[0] };
+
+    auto result = bleValueParser.make_value<BodyCompositionFeature>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_TRUE(result->isTimeStampSupported());
+    EXPECT_FALSE(result->isMultipleUsersSupported());
+    EXPECT_TRUE(result->isBasalMetabolismSupported());
+    EXPECT_FALSE(result->isMusclePercentageSupported());
+    EXPECT_TRUE(result->isMuscleMassSupported());
+    EXPECT_FALSE(result->isFatFreeMassSupported());
+    EXPECT_TRUE(result->isSoftLeanMassSupported());
+    EXPECT_FALSE(result->isBodyWaterMassSupported());
+    EXPECT_TRUE(result->isImpedanceSupported());
+    EXPECT_FALSE(result->isWeightSupported());
+    EXPECT_TRUE(result->isHeightSupported());
+    EXPECT_EQ(100, result->weightResolution());
+    EXPECT_EQ(1, result->heightResolution());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(105813, btSpecObj.flags);
+
+    EXPECT_EQ("Features: { TimeStamp BasalMetabolism MuscleMass SoftLeanMass Impedance Height }, HeightResolution: 0.001m", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_EQ(200, result->weightResolution());
+    EXPECT_EQ(100, result->heightResolution());
+    EXPECT_EQ("Features: { TimeStamp BasalMetabolism MuscleMass SoftLeanMass Impedance Height }, HeightResolution: 0.1in", result->toString());
+}
+
+TEST_F(BodyCompositionFeatureTest, FeaturesPat1_WeightRes0050_HeightResReserved_ReservedEven)
+{
+    //                             RRRRRRRR       RRRRRRHH       HWWWWFFF       FFFFFFFF
+    constexpr char flags[] = { C(0b10101010), C(0b10101010), C(0b00100110), C(0b11011011) };
+    constexpr char data[] = { flags[3], flags[2], flags[1], flags[0] };
+
+    auto result = bleValueParser.make_value<BodyCompositionFeature>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_TRUE(result->isTimeStampSupported());
+    EXPECT_TRUE(result->isMultipleUsersSupported());
+    EXPECT_FALSE(result->isBasalMetabolismSupported());
+    EXPECT_TRUE(result->isMusclePercentageSupported());
+    EXPECT_TRUE(result->isMuscleMassSupported());
+    EXPECT_FALSE(result->isFatFreeMassSupported());
+    EXPECT_TRUE(result->isSoftLeanMassSupported());
+    EXPECT_TRUE(result->isBodyWaterMassSupported());
+    EXPECT_FALSE(result->isImpedanceSupported());
+    EXPECT_TRUE(result->isWeightSupported());
+    EXPECT_TRUE(result->isHeightSupported());
+    EXPECT_EQ(50, result->weightResolution());
+    EXPECT_EQ(0, result->heightResolution());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(2863277787, btSpecObj.flags);
+
+    EXPECT_EQ("Features: { TimeStamp MultipleUsers MusclePercentage MuscleMass SoftLeanMass BodyWaterMass Weight Height }, WeightResolution: 0.05kg, HeightResolution: 0m", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_EQ(100, result->weightResolution());
+    EXPECT_EQ(0, result->heightResolution());
+    EXPECT_EQ("Features: { TimeStamp MultipleUsers MusclePercentage MuscleMass SoftLeanMass BodyWaterMass Weight Height }, WeightResolution: 0.1lb, HeightResolution: 0in", result->toString());
+}
+
+TEST_F(BodyCompositionFeatureTest, FeaturesPat2_WeightRes0020_HeightRes0001_ReservedOdd)
+{
+    //                             RRRRRRRR       RRRRRRHH       HWWWWFFF       FFFFFFFF
+    constexpr char flags[] = { C(0b01010101), C(0b01010101), C(0b10101001), C(0b00100100) };
+    constexpr char data[] = { flags[3], flags[2], flags[1], flags[0] };
+
+    auto result = bleValueParser.make_value<BodyCompositionFeature>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isTimeStampSupported());
+    EXPECT_FALSE(result->isMultipleUsersSupported());
+    EXPECT_TRUE(result->isBasalMetabolismSupported());
+    EXPECT_FALSE(result->isMusclePercentageSupported());
+    EXPECT_FALSE(result->isMuscleMassSupported());
+    EXPECT_TRUE(result->isFatFreeMassSupported());
+    EXPECT_FALSE(result->isSoftLeanMassSupported());
+    EXPECT_FALSE(result->isBodyWaterMassSupported());
+    EXPECT_TRUE(result->isImpedanceSupported());
+    EXPECT_FALSE(result->isWeightSupported());
+    EXPECT_FALSE(result->isHeightSupported());
+    EXPECT_EQ(20, result->weightResolution());
+    EXPECT_EQ(1, result->heightResolution());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(1431677220, btSpecObj.flags);
+
+    EXPECT_EQ("Features: { BasalMetabolism FatFreeMass Impedance }", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_EQ(50, result->weightResolution());
+    EXPECT_EQ(100, result->heightResolution());
+    EXPECT_EQ("Features: { BasalMetabolism FatFreeMass Impedance }", result->toString());
+}
+
+TEST_F(BodyCompositionFeatureTest, FeaturesPat3_WeightRes0010_HeightRes0005_ReservedAll)
+{
+    //                             RRRRRRRR       RRRRRRHH       HWWWWFFF       FFFFFFFF
+    constexpr char flags[] = { C(0b11111111), C(0b11111101), C(0b00110011), C(0b10110100) };
+    constexpr char data[] = { flags[3], flags[2], flags[1], flags[0] };
+
+    auto result = bleValueParser.make_value<BodyCompositionFeature>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isTimeStampSupported());
+    EXPECT_FALSE(result->isMultipleUsersSupported());
+    EXPECT_TRUE(result->isBasalMetabolismSupported());
+    EXPECT_FALSE(result->isMusclePercentageSupported());
+    EXPECT_TRUE(result->isMuscleMassSupported());
+    EXPECT_TRUE(result->isFatFreeMassSupported());
+    EXPECT_FALSE(result->isSoftLeanMassSupported());
+    EXPECT_TRUE(result->isBodyWaterMassSupported());
+    EXPECT_TRUE(result->isImpedanceSupported());
+    EXPECT_TRUE(result->isWeightSupported());
+    EXPECT_FALSE(result->isHeightSupported());
+    EXPECT_EQ(10, result->weightResolution());
+    EXPECT_EQ(5, result->heightResolution());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(4294783924, btSpecObj.flags);
+
+    EXPECT_EQ("Features: { BasalMetabolism MuscleMass FatFreeMass BodyWaterMass Impedance Weight }, WeightResolution: 0.01kg", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_EQ(20, result->weightResolution());
+    EXPECT_EQ(500, result->heightResolution());
+    EXPECT_EQ("Features: { BasalMetabolism MuscleMass FatFreeMass BodyWaterMass Impedance Weight }, WeightResolution: 0.02lb", result->toString());
+}
+
+TEST_F(BodyCompositionFeatureTest, FeaturesPat4_WeightRes0005_HeightRes0010_ReservedNone)
+{
+    //                             RRRRRRRR       RRRRRRHH       HWWWWFFF       FFFFFFFF
+    constexpr char flags[] = { C(0b00000000), C(0b00000000), C(0b10111001), C(0b01101110) };
+    constexpr char data[] = { flags[3], flags[2], flags[1], flags[0] };
+
+    auto result = bleValueParser.make_value<BodyCompositionFeature>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isTimeStampSupported());
+    EXPECT_TRUE(result->isMultipleUsersSupported());
+    EXPECT_TRUE(result->isBasalMetabolismSupported());
+    EXPECT_TRUE(result->isMusclePercentageSupported());
+    EXPECT_FALSE(result->isMuscleMassSupported());
+    EXPECT_TRUE(result->isFatFreeMassSupported());
+    EXPECT_TRUE(result->isSoftLeanMassSupported());
+    EXPECT_FALSE(result->isBodyWaterMassSupported());
+    EXPECT_TRUE(result->isImpedanceSupported());
+    EXPECT_FALSE(result->isWeightSupported());
+    EXPECT_FALSE(result->isHeightSupported());
+    EXPECT_EQ(5, result->weightResolution());
+    EXPECT_EQ(10, result->heightResolution());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(47470, btSpecObj.flags);
+
+    EXPECT_EQ("Features: { MultipleUsers BasalMetabolism MusclePercentage FatFreeMass SoftLeanMass Impedance }", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_EQ(10, result->weightResolution());
+    EXPECT_EQ(1000, result->heightResolution());
+    EXPECT_EQ("Features: { MultipleUsers BasalMetabolism MusclePercentage FatFreeMass SoftLeanMass Impedance }", result->toString());
+}
+
+TEST_F(BodyCompositionFeatureTest, FeaturesPat5_WeightResReserved_HeightResNotSpec_ReservedEven)
+{
+    //                             RRRRRRRR       RRRRRRHH       HWWWWFFF       FFFFFFFF
+    constexpr char flags[] = { C(0b10101010), C(0b10101000), C(0b01000001), C(0b10011001) };
+    constexpr char data[] = { flags[3], flags[2], flags[1], flags[0] };
+
+    auto result = bleValueParser.make_value<BodyCompositionFeature>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_TRUE(result->isTimeStampSupported());
+    EXPECT_FALSE(result->isMultipleUsersSupported());
+    EXPECT_FALSE(result->isBasalMetabolismSupported());
+    EXPECT_TRUE(result->isMusclePercentageSupported());
+    EXPECT_TRUE(result->isMuscleMassSupported());
+    EXPECT_FALSE(result->isFatFreeMassSupported());
+    EXPECT_FALSE(result->isSoftLeanMassSupported());
+    EXPECT_TRUE(result->isBodyWaterMassSupported());
+    EXPECT_TRUE(result->isImpedanceSupported());
+    EXPECT_FALSE(result->isWeightSupported());
+    EXPECT_FALSE(result->isHeightSupported());
+    EXPECT_EQ(0, result->weightResolution());
+    EXPECT_EQ(0, result->heightResolution());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(2863153561, btSpecObj.flags);
+
+    EXPECT_EQ("Features: { TimeStamp MusclePercentage MuscleMass BodyWaterMass Impedance }", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_EQ(0, result->weightResolution());
+    EXPECT_EQ(0, result->heightResolution());
+    EXPECT_EQ("Features: { TimeStamp MusclePercentage MuscleMass BodyWaterMass Impedance }", result->toString());
+}
+
+TEST_F(BodyCompositionFeatureTest, ToString)
+{
+    //                             RRRRRRRR       RRRRRRHH       HWWWWFFF       FFFFFFFF
+    constexpr char flags[] = { C(0b10101010), C(0b10101010), C(0b00100110), C(0b11011011) };
+    constexpr char data[] = { flags[3], flags[2], flags[1], flags[0] };
+
+    auto result = bleValueParser.make_value(CharacteristicType::BodyCompositionFeature,
+                                            data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+
+    EXPECT_EQ("Features: { TimeStamp MultipleUsers MusclePercentage MuscleMass SoftLeanMass BodyWaterMass Weight Height }, WeightResolution: 0.05kg, HeightResolution: 0m", result->toString());
+}
+
+}  // namespace bvp

--- a/tests/bodycompositionmeasurementmibfstest.cpp
+++ b/tests/bodycompositionmeasurementmibfstest.cpp
@@ -1,0 +1,467 @@
+#include "gtest/gtest.h"
+
+#include "blevalueparser.h"
+
+#define C(x) static_cast<char>(x)
+
+
+namespace bvp
+{
+
+class BodyCompositionMeasurementMIBFSTest : public testing::Test
+{
+protected:
+    explicit BodyCompositionMeasurementMIBFSTest() {}
+    virtual ~BodyCompositionMeasurementMIBFSTest() {}
+
+    BLEValueParser bleValueParser;
+
+//    virtual void SetUp() {}
+//    virtual void TearDown() {}
+};
+
+TEST_F(BodyCompositionMeasurementMIBFSTest, NoImpendance_Unstable_Loaded)
+{
+    //                             RRRMFFFF       FFFFFFFU
+    constexpr char flags[] = { C(0b00000100), C(0b00000010) };
+    constexpr char data[] = {
+        flags[1], flags[0],                                     // flags
+        '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
+        '\x12', '\x34',                                         // impedance
+        '\x56', '\x78'                                          // weight
+    };
+
+    auto result = bleValueParser.make_value<BodyCompositionMeasurementMIBFS>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isMeasurementUnsuccessful());
+    EXPECT_EQ(MeasurementUnitsEnum::SI, result->measurementUnits());
+    EXPECT_TRUE(result->isTimeStampPresent());
+    EXPECT_FALSE(result->isUserIDPresent());
+    EXPECT_FALSE(result->isBasalMetabolismPresent());
+    EXPECT_FALSE(result->isMusclePercentagePresent());
+    EXPECT_FALSE(result->isMuscleMassPresent());
+    EXPECT_FALSE(result->isFatFreeMassPresent());
+    EXPECT_FALSE(result->isSoftLeanMassPresent());
+    EXPECT_FALSE(result->isBodyWaterMassPresent());
+    EXPECT_FALSE(result->isImpedancePresent());
+    EXPECT_TRUE(result->isWeightPresent());
+    EXPECT_FALSE(result->isHeightPresent());
+    EXPECT_FALSE(result->isMultiplePacketMeasurement());
+    EXPECT_FLOAT_EQ(0.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(0, result->userID());
+    EXPECT_EQ(0, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(0.0, result->musclePercentage());
+    EXPECT_FLOAT_EQ(0.0, result->muscleMass());
+    EXPECT_FLOAT_EQ(0.0, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(0.0, result->softLeanMass());
+    EXPECT_FLOAT_EQ(0.0, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(1333.0, result->impedance());
+    EXPECT_FLOAT_EQ(154.03, result->weight());
+    EXPECT_FLOAT_EQ(0.0, result->height());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(1026, btSpecObj.flags);
+    EXPECT_EQ(0, btSpecObj.bodyFatPercentage);
+    EXPECT_EQ(2023, btSpecObj.timeStamp.year);
+    EXPECT_EQ(02, btSpecObj.timeStamp.month);
+    EXPECT_EQ(06, btSpecObj.timeStamp.day);
+    EXPECT_EQ(18, btSpecObj.timeStamp.hour);
+    EXPECT_EQ(28, btSpecObj.timeStamp.minute);
+    EXPECT_EQ(00, btSpecObj.timeStamp.seconds);
+    EXPECT_EQ(0, btSpecObj.userID.userIndex);
+    EXPECT_EQ(0, btSpecObj.basalMetabolism);
+    EXPECT_EQ(0, btSpecObj.musclePercentage);
+    EXPECT_EQ(0, btSpecObj.muscleMass);
+    EXPECT_EQ(0, btSpecObj.fatFreeMass);
+    EXPECT_EQ(0, btSpecObj.softLeanMass);
+    EXPECT_EQ(0, btSpecObj.bodyWaterMass);
+    EXPECT_EQ(0x3412, btSpecObj.impedance);
+    EXPECT_EQ(0x7856, btSpecObj.weight);
+    EXPECT_EQ(0, btSpecObj.height);
+
+    EXPECT_EQ("Unstable, TimeStamp: 06.02.2023 18:28:00, Weight: 154.03kg", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_FLOAT_EQ(0.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(0, result->userID());
+    EXPECT_EQ(0, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(0.0, result->musclePercentage());
+    EXPECT_FLOAT_EQ(0.0, result->muscleMass());
+    EXPECT_FLOAT_EQ(0.0, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(0.0, result->softLeanMass());
+    EXPECT_FLOAT_EQ(0.0, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(1333.0, result->impedance());
+    EXPECT_FLOAT_EQ(308.06, result->weight());
+    EXPECT_FLOAT_EQ(0.0, result->height());
+    EXPECT_EQ("Unstable, TimeStamp: 06.02.2023 18:28:00, Weight: 308.06lb", result->toString());
+}
+
+TEST_F(BodyCompositionMeasurementMIBFSTest, HasImpendance_Stabilized_Loaded)
+{
+    //                             RRRMFFFF       FFFFFFFU
+    constexpr char flags[] = { C(0b00100110), C(0b00000010) };
+    constexpr char data[] = {
+        flags[1], flags[0],                                     // flags
+        '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
+        '\x12', '\x34',                                         // impedance
+        '\x56', '\x78'                                          // weight
+    };
+
+    auto result = bleValueParser.make_value<BodyCompositionMeasurementMIBFS>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isMeasurementUnsuccessful());
+    EXPECT_EQ(MeasurementUnitsEnum::SI, result->measurementUnits());
+    EXPECT_TRUE(result->isTimeStampPresent());
+    EXPECT_FALSE(result->isUserIDPresent());
+    EXPECT_FALSE(result->isBasalMetabolismPresent());
+    EXPECT_FALSE(result->isMusclePercentagePresent());
+    EXPECT_FALSE(result->isMuscleMassPresent());
+    EXPECT_FALSE(result->isFatFreeMassPresent());
+    EXPECT_FALSE(result->isSoftLeanMassPresent());
+    EXPECT_FALSE(result->isBodyWaterMassPresent());
+    EXPECT_TRUE(result->isImpedancePresent());
+    EXPECT_TRUE(result->isWeightPresent());
+    EXPECT_FALSE(result->isHeightPresent());
+    EXPECT_FALSE(result->isMultiplePacketMeasurement());
+    EXPECT_FLOAT_EQ(0.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(0, result->userID());
+    EXPECT_EQ(0, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(0.0, result->musclePercentage());
+    EXPECT_FLOAT_EQ(0.0, result->muscleMass());
+    EXPECT_FLOAT_EQ(0.0, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(0.0, result->softLeanMass());
+    EXPECT_FLOAT_EQ(0.0, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(1333.0, result->impedance());
+    EXPECT_FLOAT_EQ(154.03, result->weight());
+    EXPECT_FLOAT_EQ(0.0, result->height());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(9730, btSpecObj.flags);
+    EXPECT_EQ(0, btSpecObj.bodyFatPercentage);
+    EXPECT_EQ(2023, btSpecObj.timeStamp.year);
+    EXPECT_EQ(02, btSpecObj.timeStamp.month);
+    EXPECT_EQ(06, btSpecObj.timeStamp.day);
+    EXPECT_EQ(18, btSpecObj.timeStamp.hour);
+    EXPECT_EQ(28, btSpecObj.timeStamp.minute);
+    EXPECT_EQ(00, btSpecObj.timeStamp.seconds);
+    EXPECT_EQ(0, btSpecObj.userID.userIndex);
+    EXPECT_EQ(0, btSpecObj.basalMetabolism);
+    EXPECT_EQ(0, btSpecObj.musclePercentage);
+    EXPECT_EQ(0, btSpecObj.muscleMass);
+    EXPECT_EQ(0, btSpecObj.fatFreeMass);
+    EXPECT_EQ(0, btSpecObj.softLeanMass);
+    EXPECT_EQ(0, btSpecObj.bodyWaterMass);
+    EXPECT_EQ(0x3412, btSpecObj.impedance);
+    EXPECT_EQ(0x7856, btSpecObj.weight);
+    EXPECT_EQ(0, btSpecObj.height);
+
+    EXPECT_EQ("Stabilized, TimeStamp: 06.02.2023 18:28:00, Impedance: 1333Ω, Weight: 154.03kg", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_FLOAT_EQ(0.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(0, result->userID());
+    EXPECT_EQ(0, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(0.0, result->musclePercentage());
+    EXPECT_FLOAT_EQ(0.0, result->muscleMass());
+    EXPECT_FLOAT_EQ(0.0, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(0.0, result->softLeanMass());
+    EXPECT_FLOAT_EQ(0.0, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(1333.0, result->impedance());
+    EXPECT_FLOAT_EQ(308.06, result->weight());
+    EXPECT_FLOAT_EQ(0.0, result->height());
+    EXPECT_EQ("Stabilized, TimeStamp: 06.02.2023 18:28:00, Impedance: 1333Ω, Weight: 308.06lb", result->toString());
+}
+
+TEST_F(BodyCompositionMeasurementMIBFSTest, NoImpendance_Unstable_Unloaded)
+{
+    //                             RRRMFFFF       FFFFFFFU
+    constexpr char flags[] = { C(0b10000100), C(0b00000010) };
+    constexpr char data[] = {
+        flags[1], flags[0],                                     // flags
+        '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
+        '\x12', '\x34',                                         // impedance
+        '\x56', '\x78'                                          // weight
+    };
+
+    auto result = bleValueParser.make_value<BodyCompositionMeasurementMIBFS>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isMeasurementUnsuccessful());
+    EXPECT_EQ(MeasurementUnitsEnum::SI, result->measurementUnits());
+    EXPECT_TRUE(result->isTimeStampPresent());
+    EXPECT_FALSE(result->isUserIDPresent());
+    EXPECT_FALSE(result->isBasalMetabolismPresent());
+    EXPECT_FALSE(result->isMusclePercentagePresent());
+    EXPECT_FALSE(result->isMuscleMassPresent());
+    EXPECT_FALSE(result->isFatFreeMassPresent());
+    EXPECT_FALSE(result->isSoftLeanMassPresent());
+    EXPECT_FALSE(result->isBodyWaterMassPresent());
+    EXPECT_FALSE(result->isImpedancePresent());
+    EXPECT_TRUE(result->isWeightPresent());
+    EXPECT_FALSE(result->isHeightPresent());
+    EXPECT_FALSE(result->isMultiplePacketMeasurement());
+    EXPECT_FLOAT_EQ(0.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(0, result->userID());
+    EXPECT_EQ(0, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(0.0, result->musclePercentage());
+    EXPECT_FLOAT_EQ(0.0, result->muscleMass());
+    EXPECT_FLOAT_EQ(0.0, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(0.0, result->softLeanMass());
+    EXPECT_FLOAT_EQ(0.0, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(1333.0, result->impedance());
+    EXPECT_FLOAT_EQ(154.03, result->weight());
+    EXPECT_FLOAT_EQ(0.0, result->height());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(33794, btSpecObj.flags);
+    EXPECT_EQ(0, btSpecObj.bodyFatPercentage);
+    EXPECT_EQ(2023, btSpecObj.timeStamp.year);
+    EXPECT_EQ(02, btSpecObj.timeStamp.month);
+    EXPECT_EQ(06, btSpecObj.timeStamp.day);
+    EXPECT_EQ(18, btSpecObj.timeStamp.hour);
+    EXPECT_EQ(28, btSpecObj.timeStamp.minute);
+    EXPECT_EQ(00, btSpecObj.timeStamp.seconds);
+    EXPECT_EQ(0, btSpecObj.userID.userIndex);
+    EXPECT_EQ(0, btSpecObj.basalMetabolism);
+    EXPECT_EQ(0, btSpecObj.musclePercentage);
+    EXPECT_EQ(0, btSpecObj.muscleMass);
+    EXPECT_EQ(0, btSpecObj.fatFreeMass);
+    EXPECT_EQ(0, btSpecObj.softLeanMass);
+    EXPECT_EQ(0, btSpecObj.bodyWaterMass);
+    EXPECT_EQ(0x3412, btSpecObj.impedance);
+    EXPECT_EQ(0x7856, btSpecObj.weight);
+    EXPECT_EQ(0, btSpecObj.height);
+
+    EXPECT_EQ("Unloaded, TimeStamp: 06.02.2023 18:28:00, Weight: 154.03kg", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_FLOAT_EQ(0.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(0, result->userID());
+    EXPECT_EQ(0, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(0.0, result->musclePercentage());
+    EXPECT_FLOAT_EQ(0.0, result->muscleMass());
+    EXPECT_FLOAT_EQ(0.0, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(0.0, result->softLeanMass());
+    EXPECT_FLOAT_EQ(0.0, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(1333.0, result->impedance());
+    EXPECT_FLOAT_EQ(308.06, result->weight());
+    EXPECT_FLOAT_EQ(0.0, result->height());
+    EXPECT_EQ("Unloaded, TimeStamp: 06.02.2023 18:28:00, Weight: 308.06lb", result->toString());
+}
+
+TEST_F(BodyCompositionMeasurementMIBFSTest, HasImpendance_Stabilized_Unloaded)
+{
+    //                           RRRMFFFF    FFFFFFFU
+    constexpr char flags[] = { C(0b10100110), C(0b00000010) };
+    constexpr char data[] = {
+        flags[1], flags[0],                                     // flags
+        '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
+        '\x12', '\x34',                                         // impedance
+        '\x56', '\x78'                                          // weight
+    };
+
+    auto result = bleValueParser.make_value<BodyCompositionMeasurementMIBFS>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isMeasurementUnsuccessful());
+    EXPECT_EQ(MeasurementUnitsEnum::SI, result->measurementUnits());
+    EXPECT_TRUE(result->isTimeStampPresent());
+    EXPECT_FALSE(result->isUserIDPresent());
+    EXPECT_FALSE(result->isBasalMetabolismPresent());
+    EXPECT_FALSE(result->isMusclePercentagePresent());
+    EXPECT_FALSE(result->isMuscleMassPresent());
+    EXPECT_FALSE(result->isFatFreeMassPresent());
+    EXPECT_FALSE(result->isSoftLeanMassPresent());
+    EXPECT_FALSE(result->isBodyWaterMassPresent());
+    EXPECT_TRUE(result->isImpedancePresent());
+    EXPECT_TRUE(result->isWeightPresent());
+    EXPECT_FALSE(result->isHeightPresent());
+    EXPECT_FALSE(result->isMultiplePacketMeasurement());
+    EXPECT_FLOAT_EQ(0.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(0, result->userID());
+    EXPECT_EQ(0, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(0.0, result->musclePercentage());
+    EXPECT_FLOAT_EQ(0.0, result->muscleMass());
+    EXPECT_FLOAT_EQ(0.0, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(0.0, result->softLeanMass());
+    EXPECT_FLOAT_EQ(0.0, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(1333.0, result->impedance());
+    EXPECT_FLOAT_EQ(154.03, result->weight());
+    EXPECT_FLOAT_EQ(0.0, result->height());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(42498, btSpecObj.flags);
+    EXPECT_EQ(0, btSpecObj.bodyFatPercentage);
+    EXPECT_EQ(2023, btSpecObj.timeStamp.year);
+    EXPECT_EQ(02, btSpecObj.timeStamp.month);
+    EXPECT_EQ(06, btSpecObj.timeStamp.day);
+    EXPECT_EQ(18, btSpecObj.timeStamp.hour);
+    EXPECT_EQ(28, btSpecObj.timeStamp.minute);
+    EXPECT_EQ(00, btSpecObj.timeStamp.seconds);
+    EXPECT_EQ(0, btSpecObj.userID.userIndex);
+    EXPECT_EQ(0, btSpecObj.basalMetabolism);
+    EXPECT_EQ(0, btSpecObj.musclePercentage);
+    EXPECT_EQ(0, btSpecObj.muscleMass);
+    EXPECT_EQ(0, btSpecObj.fatFreeMass);
+    EXPECT_EQ(0, btSpecObj.softLeanMass);
+    EXPECT_EQ(0, btSpecObj.bodyWaterMass);
+    EXPECT_EQ(0x3412, btSpecObj.impedance);
+    EXPECT_EQ(0x7856, btSpecObj.weight);
+    EXPECT_EQ(0, btSpecObj.height);
+
+    EXPECT_EQ("Unloaded, TimeStamp: 06.02.2023 18:28:00, Impedance: 1333Ω, Weight: 154.03kg", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_FLOAT_EQ(0.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(0, result->userID());
+    EXPECT_EQ(0, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(0.0, result->musclePercentage());
+    EXPECT_FLOAT_EQ(0.0, result->muscleMass());
+    EXPECT_FLOAT_EQ(0.0, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(0.0, result->softLeanMass());
+    EXPECT_FLOAT_EQ(0.0, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(1333.0, result->impedance());
+    EXPECT_FLOAT_EQ(308.06, result->weight());
+    EXPECT_FLOAT_EQ(0.0, result->height());
+    EXPECT_EQ("Unloaded, TimeStamp: 06.02.2023 18:28:00, Impedance: 1333Ω, Weight: 308.06lb", result->toString());
+}
+
+TEST_F(BodyCompositionMeasurementMIBFSTest, Imperial)
+{
+    //                             RRRMFFFF       FFFFFFFU
+    constexpr char flags[] = { C(0b00000100), C(0b00000011) };
+    constexpr char data[] = {
+        flags[1], flags[0],                                     // flags
+        '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
+        '\x12', '\x34',                                         // impedance
+        '\x56', '\x78'                                          // weight
+    };
+
+    auto result = bleValueParser.make_value<BodyCompositionMeasurementMIBFS>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isMeasurementUnsuccessful());
+    EXPECT_EQ(MeasurementUnitsEnum::Imperial, result->measurementUnits());
+    EXPECT_TRUE(result->isTimeStampPresent());
+    EXPECT_FALSE(result->isUserIDPresent());
+    EXPECT_FALSE(result->isBasalMetabolismPresent());
+    EXPECT_FALSE(result->isMusclePercentagePresent());
+    EXPECT_FALSE(result->isMuscleMassPresent());
+    EXPECT_FALSE(result->isFatFreeMassPresent());
+    EXPECT_FALSE(result->isSoftLeanMassPresent());
+    EXPECT_FALSE(result->isBodyWaterMassPresent());
+    EXPECT_FALSE(result->isImpedancePresent());
+    EXPECT_TRUE(result->isWeightPresent());
+    EXPECT_FALSE(result->isHeightPresent());
+    EXPECT_FALSE(result->isMultiplePacketMeasurement());
+    EXPECT_FLOAT_EQ(0.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(0, result->userID());
+    EXPECT_EQ(0, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(0.0, result->musclePercentage());
+    EXPECT_FLOAT_EQ(0.0, result->muscleMass());
+    EXPECT_FLOAT_EQ(0.0, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(0.0, result->softLeanMass());
+    EXPECT_FLOAT_EQ(0.0, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(1333.0, result->impedance());
+    EXPECT_FLOAT_EQ(308.06, result->weight());
+    EXPECT_FLOAT_EQ(0.0, result->height());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(1027, btSpecObj.flags);
+    EXPECT_EQ(0, btSpecObj.bodyFatPercentage);
+    EXPECT_EQ(2023, btSpecObj.timeStamp.year);
+    EXPECT_EQ(02, btSpecObj.timeStamp.month);
+    EXPECT_EQ(06, btSpecObj.timeStamp.day);
+    EXPECT_EQ(18, btSpecObj.timeStamp.hour);
+    EXPECT_EQ(28, btSpecObj.timeStamp.minute);
+    EXPECT_EQ(00, btSpecObj.timeStamp.seconds);
+    EXPECT_EQ(0, btSpecObj.userID.userIndex);
+    EXPECT_EQ(0, btSpecObj.basalMetabolism);
+    EXPECT_EQ(0, btSpecObj.musclePercentage);
+    EXPECT_EQ(0, btSpecObj.muscleMass);
+    EXPECT_EQ(0, btSpecObj.fatFreeMass);
+    EXPECT_EQ(0, btSpecObj.softLeanMass);
+    EXPECT_EQ(0, btSpecObj.bodyWaterMass);
+    EXPECT_EQ(0x3412, btSpecObj.impedance);
+    EXPECT_EQ(0x7856, btSpecObj.weight);
+    EXPECT_EQ(0, btSpecObj.height);
+
+    EXPECT_EQ("Unstable, TimeStamp: 06.02.2023 18:28:00, Weight: 308.06lb", result->toString());
+}
+
+TEST_F(BodyCompositionMeasurementMIBFSTest, ToString)
+{
+    //                           RRRMFFFF    FFFFFFFU
+    constexpr char flags[] = { 0b00000100, 0b00000010 };
+    constexpr char data[] = {
+        flags[1], flags[0],                                     // flags
+        '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
+        '\x00', '\x00',                                         // impedance
+        '\xE0', '\x38'                                          // weight
+    };
+
+    auto result = bleValueParser.make_value(CharacteristicType::BodyCompositionMeasurementMIBFS,
+                                            data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+
+    EXPECT_EQ("Unstable, TimeStamp: 06.02.2023 18:28:00, Weight: 72.8kg", result->toString());
+}
+
+}  // namespace bvp

--- a/tests/bodycompositionmeasurementtest.cpp
+++ b/tests/bodycompositionmeasurementtest.cpp
@@ -1,0 +1,519 @@
+#include "gtest/gtest.h"
+
+#include "blevalueparser.h"
+
+#define C(x) static_cast<char>(x)
+
+
+namespace bvp
+{
+
+class BodyCompositionMeasurementTest : public testing::Test
+{
+protected:
+    explicit BodyCompositionMeasurementTest() {}
+    virtual ~BodyCompositionMeasurementTest() {}
+
+    BLEValueParser bleValueParser;
+
+//    virtual void SetUp() {}
+//    virtual void TearDown() {}
+};
+
+TEST_F(BodyCompositionMeasurementTest, FeaturesAll_SinglePacket_ReservedOdd)
+{
+    //                             RRRMFFFF       FFFFFFFU
+    constexpr char flags[] = { C(0b10101111), C(0b11111110) };
+    constexpr char data[] = {
+        flags[1], flags[0],                                     // flags
+        '\x12', '\x34',                                         // bodyFatPercentage
+        '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
+        '\x2A',                                                 // userID
+        '\x23', '\x45',                                         // basalMetabolism
+        '\x34', '\x56',                                         // musclePercentage
+        '\x45', '\x67',                                         // muscleMass
+        '\x56', '\x78',                                         // fatFreeMass
+        '\x67', '\x89',                                         // softLeanMass
+        '\x78', '\x9A',                                         // bodyWaterMass
+        '\x89', '\xAB',                                         // impedance
+        '\x9A', '\xBC',                                         // weight
+        '\xAB', '\xCD'                                          // height
+    };
+
+    auto result = bleValueParser.make_value<BodyCompositionMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isMeasurementUnsuccessful());
+    EXPECT_EQ(MeasurementUnitsEnum::SI, result->measurementUnits());
+    EXPECT_TRUE(result->isTimeStampPresent());
+    EXPECT_TRUE(result->isUserIDPresent());
+    EXPECT_TRUE(result->isBasalMetabolismPresent());
+    EXPECT_TRUE(result->isMusclePercentagePresent());
+    EXPECT_TRUE(result->isMuscleMassPresent());
+    EXPECT_TRUE(result->isFatFreeMassPresent());
+    EXPECT_TRUE(result->isSoftLeanMassPresent());
+    EXPECT_TRUE(result->isBodyWaterMassPresent());
+    EXPECT_TRUE(result->isImpedancePresent());
+    EXPECT_TRUE(result->isWeightPresent());
+    EXPECT_TRUE(result->isHeightPresent());
+    EXPECT_FALSE(result->isMultiplePacketMeasurement());
+    EXPECT_FLOAT_EQ(1333.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(42, result->userID());
+    EXPECT_EQ(17699, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(2206.8, result->musclePercentage());
+    EXPECT_FLOAT_EQ(132.185, result->muscleMass());
+    EXPECT_FLOAT_EQ(154.03, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(175.875, result->softLeanMass());
+    EXPECT_FLOAT_EQ(197.72, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(4391.3, result->impedance());
+    EXPECT_FLOAT_EQ(241.40999, result->weight());
+    EXPECT_FLOAT_EQ(52.651, result->height());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(45054, btSpecObj.flags);
+    EXPECT_EQ(0x3412, btSpecObj.bodyFatPercentage);
+    EXPECT_EQ(2023, btSpecObj.timeStamp.year);
+    EXPECT_EQ(02, btSpecObj.timeStamp.month);
+    EXPECT_EQ(06, btSpecObj.timeStamp.day);
+    EXPECT_EQ(18, btSpecObj.timeStamp.hour);
+    EXPECT_EQ(28, btSpecObj.timeStamp.minute);
+    EXPECT_EQ(00, btSpecObj.timeStamp.seconds);
+    EXPECT_EQ(42, btSpecObj.userID.userIndex);
+    EXPECT_EQ(0x4523, btSpecObj.basalMetabolism);
+    EXPECT_EQ(0x5634, btSpecObj.musclePercentage);
+    EXPECT_EQ(0x6745, btSpecObj.muscleMass);
+    EXPECT_EQ(0x7856, btSpecObj.fatFreeMass);
+    EXPECT_EQ(0x8967, btSpecObj.softLeanMass);
+    EXPECT_EQ(0x9A78, btSpecObj.bodyWaterMass);
+    EXPECT_EQ(0xAB89, btSpecObj.impedance);
+    EXPECT_EQ(0xBC9A, btSpecObj.weight);
+    EXPECT_EQ(0xCDAB, btSpecObj.height);
+
+    EXPECT_EQ("BodyFatPercentage: 1333%, TimeStamp: 06.02.2023 18:28:00, UserID: 42, BasalMetabolism: 17699kJ, MusclePercentage: 2206.8%, MuscleMass: 132.185kg, FatFreeMass: 154.03kg, SoftLeanMass: 175.875kg, BodyWaterMass: 197.72kg, Impedance: 4391.3Ω, Weight: 241.41kg, Height: 52.651m", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_FLOAT_EQ(1333.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(42, result->userID());
+    EXPECT_EQ(17699, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(2206.8, result->musclePercentage());
+    EXPECT_FLOAT_EQ(264.37, result->muscleMass());
+    EXPECT_FLOAT_EQ(308.06, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(351.75, result->softLeanMass());
+    EXPECT_FLOAT_EQ(395.44, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(4391.3, result->impedance());
+    EXPECT_FLOAT_EQ(482.81998, result->weight());
+    EXPECT_FLOAT_EQ(5265.1, result->height());
+    EXPECT_EQ("BodyFatPercentage: 1333%, TimeStamp: 06.02.2023 18:28:00, UserID: 42, BasalMetabolism: 17699kJ, MusclePercentage: 2206.8%, MuscleMass: 264.37lb, FatFreeMass: 308.06lb, SoftLeanMass: 351.75lb, BodyWaterMass: 395.44lb, Impedance: 4391.3Ω, Weight: 482.82lb, Height: 5265.1in", result->toString());
+}
+
+TEST_F(BodyCompositionMeasurementTest, FeaturesNone_MultiplePacket_ReservedEven)
+{
+    //                             RRRMFFFF       FFFFFFFU
+    constexpr char flags[] = { C(0b01010000), C(0b00000000) };
+    constexpr char data[] = {
+        flags[1], flags[0],                                     // flags
+        '\x12', '\x34'                                          // bodyFatPercentage
+    };
+
+    auto result = bleValueParser.make_value<BodyCompositionMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isMeasurementUnsuccessful());
+    EXPECT_EQ(MeasurementUnitsEnum::SI, result->measurementUnits());
+    EXPECT_FALSE(result->isTimeStampPresent());
+    EXPECT_FALSE(result->isUserIDPresent());
+    EXPECT_FALSE(result->isBasalMetabolismPresent());
+    EXPECT_FALSE(result->isMusclePercentagePresent());
+    EXPECT_FALSE(result->isMuscleMassPresent());
+    EXPECT_FALSE(result->isFatFreeMassPresent());
+    EXPECT_FALSE(result->isSoftLeanMassPresent());
+    EXPECT_FALSE(result->isBodyWaterMassPresent());
+    EXPECT_FALSE(result->isImpedancePresent());
+    EXPECT_FALSE(result->isWeightPresent());
+    EXPECT_FALSE(result->isHeightPresent());
+    EXPECT_TRUE(result->isMultiplePacketMeasurement());
+    EXPECT_FLOAT_EQ(1333.0, result->bodyFatPercentage());
+    EXPECT_EQ(0, result->year());
+    EXPECT_EQ(0, result->month());
+    EXPECT_EQ(0, result->day());
+    EXPECT_EQ(0, result->hour());
+    EXPECT_EQ(0, result->minute());
+    EXPECT_EQ(0, result->seconds());
+    EXPECT_EQ(0, result->userID());
+    EXPECT_EQ(0, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(0, result->musclePercentage());
+    EXPECT_FLOAT_EQ(0, result->muscleMass());
+    EXPECT_FLOAT_EQ(0, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(0, result->softLeanMass());
+    EXPECT_FLOAT_EQ(0, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(0, result->impedance());
+    EXPECT_FLOAT_EQ(0, result->weight());
+    EXPECT_FLOAT_EQ(0, result->height());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(20480, btSpecObj.flags);
+    EXPECT_EQ(0x3412, btSpecObj.bodyFatPercentage);
+    EXPECT_EQ(0, btSpecObj.timeStamp.year);
+    EXPECT_EQ(0, btSpecObj.timeStamp.month);
+    EXPECT_EQ(0, btSpecObj.timeStamp.day);
+    EXPECT_EQ(0, btSpecObj.timeStamp.hour);
+    EXPECT_EQ(0, btSpecObj.timeStamp.minute);
+    EXPECT_EQ(0, btSpecObj.timeStamp.seconds);
+    EXPECT_EQ(0, btSpecObj.userID.userIndex);
+    EXPECT_EQ(0, btSpecObj.basalMetabolism);
+    EXPECT_EQ(0, btSpecObj.musclePercentage);
+    EXPECT_EQ(0, btSpecObj.muscleMass);
+    EXPECT_EQ(0, btSpecObj.fatFreeMass);
+    EXPECT_EQ(0, btSpecObj.softLeanMass);
+    EXPECT_EQ(0, btSpecObj.bodyWaterMass);
+    EXPECT_EQ(0, btSpecObj.impedance);
+    EXPECT_EQ(0, btSpecObj.weight);
+    EXPECT_EQ(0, btSpecObj.height);
+
+    EXPECT_EQ("BodyFatPercentage: 1333%", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_FLOAT_EQ(1333.0, result->bodyFatPercentage());
+    EXPECT_EQ(0, result->year());
+    EXPECT_EQ(0, result->month());
+    EXPECT_EQ(0, result->day());
+    EXPECT_EQ(0, result->hour());
+    EXPECT_EQ(0, result->minute());
+    EXPECT_EQ(0, result->seconds());
+    EXPECT_EQ(0, result->userID());
+    EXPECT_EQ(0, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(0, result->musclePercentage());
+    EXPECT_FLOAT_EQ(0, result->muscleMass());
+    EXPECT_FLOAT_EQ(0, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(0, result->softLeanMass());
+    EXPECT_FLOAT_EQ(0, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(0, result->impedance());
+    EXPECT_FLOAT_EQ(0, result->weight());
+    EXPECT_FLOAT_EQ(0, result->height());
+    EXPECT_EQ("BodyFatPercentage: 1333%", result->toString());
+}
+
+TEST_F(BodyCompositionMeasurementTest, FeaturesOdd_SinglePacket_ReservedAll)
+{
+    //                             RRRMFFFF       FFFFFFFU
+    constexpr char flags[] = { C(0b11101010), C(0b10101010) };
+    constexpr char data[] = {
+        flags[1], flags[0],                                     // flags
+        '\x12', '\x34',                                         // bodyFatPercentage
+        '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
+        '\x23', '\x45',                                         // basalMetabolism
+        '\x45', '\x67',                                         // muscleMass
+        '\x67', '\x89',                                         // softLeanMass
+        '\x89', '\xAB',                                         // impedance
+        '\xAB', '\xCD'                                          // height
+    };
+
+    auto result = bleValueParser.make_value<BodyCompositionMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isMeasurementUnsuccessful());
+    EXPECT_EQ(MeasurementUnitsEnum::SI, result->measurementUnits());
+    EXPECT_TRUE(result->isTimeStampPresent());
+    EXPECT_FALSE(result->isUserIDPresent());
+    EXPECT_TRUE(result->isBasalMetabolismPresent());
+    EXPECT_FALSE(result->isMusclePercentagePresent());
+    EXPECT_TRUE(result->isMuscleMassPresent());
+    EXPECT_FALSE(result->isFatFreeMassPresent());
+    EXPECT_TRUE(result->isSoftLeanMassPresent());
+    EXPECT_FALSE(result->isBodyWaterMassPresent());
+    EXPECT_TRUE(result->isImpedancePresent());
+    EXPECT_FALSE(result->isWeightPresent());
+    EXPECT_TRUE(result->isHeightPresent());
+    EXPECT_FALSE(result->isMultiplePacketMeasurement());
+    EXPECT_FLOAT_EQ(1333.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(0, result->userID());
+    EXPECT_EQ(17699, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(0.0, result->musclePercentage());
+    EXPECT_FLOAT_EQ(132.185, result->muscleMass());
+    EXPECT_FLOAT_EQ(0.0, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(175.875, result->softLeanMass());
+    EXPECT_FLOAT_EQ(0.0, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(4391.3, result->impedance());
+    EXPECT_FLOAT_EQ(0.0, result->weight());
+    EXPECT_FLOAT_EQ(52.651, result->height());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(60074, btSpecObj.flags);
+    EXPECT_EQ(0x3412, btSpecObj.bodyFatPercentage);
+    EXPECT_EQ(2023, btSpecObj.timeStamp.year);
+    EXPECT_EQ(02, btSpecObj.timeStamp.month);
+    EXPECT_EQ(06, btSpecObj.timeStamp.day);
+    EXPECT_EQ(18, btSpecObj.timeStamp.hour);
+    EXPECT_EQ(28, btSpecObj.timeStamp.minute);
+    EXPECT_EQ(00, btSpecObj.timeStamp.seconds);
+    EXPECT_EQ(0, btSpecObj.userID.userIndex);
+    EXPECT_EQ(0x4523, btSpecObj.basalMetabolism);
+    EXPECT_EQ(0, btSpecObj.musclePercentage);
+    EXPECT_EQ(0x6745, btSpecObj.muscleMass);
+    EXPECT_EQ(0, btSpecObj.fatFreeMass);
+    EXPECT_EQ(0x8967, btSpecObj.softLeanMass);
+    EXPECT_EQ(0, btSpecObj.bodyWaterMass);
+    EXPECT_EQ(0xAB89, btSpecObj.impedance);
+    EXPECT_EQ(0, btSpecObj.weight);
+    EXPECT_EQ(0xCDAB, btSpecObj.height);
+
+    EXPECT_EQ("BodyFatPercentage: 1333%, TimeStamp: 06.02.2023 18:28:00, BasalMetabolism: 17699kJ, MuscleMass: 132.185kg, SoftLeanMass: 175.875kg, Impedance: 4391.3Ω, Height: 52.651m", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_FLOAT_EQ(1333.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(0, result->userID());
+    EXPECT_EQ(17699, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(0.0, result->musclePercentage());
+    EXPECT_FLOAT_EQ(264.37, result->muscleMass());
+    EXPECT_FLOAT_EQ(0.0, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(351.75, result->softLeanMass());
+    EXPECT_FLOAT_EQ(0.0, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(4391.3, result->impedance());
+    EXPECT_FLOAT_EQ(0.0, result->weight());
+    EXPECT_FLOAT_EQ(5265.1, result->height());
+    EXPECT_EQ("BodyFatPercentage: 1333%, TimeStamp: 06.02.2023 18:28:00, BasalMetabolism: 17699kJ, MuscleMass: 264.37lb, SoftLeanMass: 351.75lb, Impedance: 4391.3Ω, Height: 5265.1in", result->toString());
+}
+
+TEST_F(BodyCompositionMeasurementTest, FeaturesEven_MultiplePacket_ReservedNone)
+{
+    //                             RRRMFFFF       FFFFFFFU
+    constexpr char flags[] = { C(0b00010101), C(0b01010100) };
+    constexpr char data[] = {
+        flags[1], flags[0],                                     // flags
+        '\x12', '\x34',                                         // bodyFatPercentage
+        '\x2A',                                                 // userID
+        '\x34', '\x56',                                         // musclePercentage
+        '\x56', '\x78',                                         // fatFreeMass
+        '\x78', '\x9A',                                         // bodyWaterMass
+        '\x9A', '\xBC'                                          // weight
+    };
+
+    auto result = bleValueParser.make_value<BodyCompositionMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isMeasurementUnsuccessful());
+    EXPECT_EQ(MeasurementUnitsEnum::SI, result->measurementUnits());
+    EXPECT_FALSE(result->isTimeStampPresent());
+    EXPECT_TRUE(result->isUserIDPresent());
+    EXPECT_FALSE(result->isBasalMetabolismPresent());
+    EXPECT_TRUE(result->isMusclePercentagePresent());
+    EXPECT_FALSE(result->isMuscleMassPresent());
+    EXPECT_TRUE(result->isFatFreeMassPresent());
+    EXPECT_FALSE(result->isSoftLeanMassPresent());
+    EXPECT_TRUE(result->isBodyWaterMassPresent());
+    EXPECT_FALSE(result->isImpedancePresent());
+    EXPECT_TRUE(result->isWeightPresent());
+    EXPECT_FALSE(result->isHeightPresent());
+    EXPECT_TRUE(result->isMultiplePacketMeasurement());
+    EXPECT_FLOAT_EQ(1333.0, result->bodyFatPercentage());
+    EXPECT_EQ(0, result->year());
+    EXPECT_EQ(0, result->month());
+    EXPECT_EQ(0, result->day());
+    EXPECT_EQ(0, result->hour());
+    EXPECT_EQ(0, result->minute());
+    EXPECT_EQ(0, result->seconds());
+    EXPECT_EQ(42, result->userID());
+    EXPECT_EQ(0, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(2206.8, result->musclePercentage());
+    EXPECT_FLOAT_EQ(0.0, result->muscleMass());
+    EXPECT_FLOAT_EQ(154.03, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(0.0, result->softLeanMass());
+    EXPECT_FLOAT_EQ(197.72, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(0.0, result->impedance());
+    EXPECT_FLOAT_EQ(241.40999, result->weight());
+    EXPECT_FLOAT_EQ(0.0, result->height());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(5460, btSpecObj.flags);
+    EXPECT_EQ(0x3412, btSpecObj.bodyFatPercentage);
+    EXPECT_EQ(0, btSpecObj.timeStamp.year);
+    EXPECT_EQ(0, btSpecObj.timeStamp.month);
+    EXPECT_EQ(0, btSpecObj.timeStamp.day);
+    EXPECT_EQ(0, btSpecObj.timeStamp.hour);
+    EXPECT_EQ(0, btSpecObj.timeStamp.minute);
+    EXPECT_EQ(0, btSpecObj.timeStamp.seconds);
+    EXPECT_EQ(42, btSpecObj.userID.userIndex);
+    EXPECT_EQ(0, btSpecObj.basalMetabolism);
+    EXPECT_EQ(0x5634, btSpecObj.musclePercentage);
+    EXPECT_EQ(0, btSpecObj.muscleMass);
+    EXPECT_EQ(0x7856, btSpecObj.fatFreeMass);
+    EXPECT_EQ(0, btSpecObj.softLeanMass);
+    EXPECT_EQ(0x9A78, btSpecObj.bodyWaterMass);
+    EXPECT_EQ(0, btSpecObj.impedance);
+    EXPECT_EQ(0xBC9A, btSpecObj.weight);
+    EXPECT_EQ(0, btSpecObj.height);
+
+    EXPECT_EQ("BodyFatPercentage: 1333%, UserID: 42, MusclePercentage: 2206.8%, FatFreeMass: 154.03kg, BodyWaterMass: 197.72kg, Weight: 241.41kg", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_FLOAT_EQ(1333.0, result->bodyFatPercentage());
+    EXPECT_EQ(0, result->year());
+    EXPECT_EQ(0, result->month());
+    EXPECT_EQ(0, result->day());
+    EXPECT_EQ(0, result->hour());
+    EXPECT_EQ(0, result->minute());
+    EXPECT_EQ(0, result->seconds());
+    EXPECT_EQ(42, result->userID());
+    EXPECT_EQ(0, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(2206.8, result->musclePercentage());
+    EXPECT_FLOAT_EQ(0.0, result->muscleMass());
+    EXPECT_FLOAT_EQ(308.06, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(0.0, result->softLeanMass());
+    EXPECT_FLOAT_EQ(395.44, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(0.0, result->impedance());
+    EXPECT_FLOAT_EQ(482.81998, result->weight());
+    EXPECT_FLOAT_EQ(0.0, result->height());
+    EXPECT_EQ("BodyFatPercentage: 1333%, UserID: 42, MusclePercentage: 2206.8%, FatFreeMass: 308.06lb, BodyWaterMass: 395.44lb, Weight: 482.82lb", result->toString());
+}
+
+TEST_F(BodyCompositionMeasurementTest, MeasurementUnsuccessful)
+{
+    //                             RRRMFFFF       FFFFFFFU
+    constexpr char flags[] = { C(0b00000000), C(0b00000000) };
+    constexpr char data[] = {
+        flags[1], flags[0],                                     // flags
+        '\xFF', '\xFF'                                          // bodyFatPercentage
+    };
+
+    auto result = bleValueParser.make_value<BodyCompositionMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_TRUE(result->isMeasurementUnsuccessful());
+
+    EXPECT_EQ("<MeasurementUnsuccessful>", result->toString());
+
+    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    EXPECT_EQ("<MeasurementUnsuccessful>", result->toString());
+}
+
+TEST_F(BodyCompositionMeasurementTest, Imperial)
+{
+    //                             RRRMFFFF       FFFFFFFU
+    constexpr char flags[] = { C(0b10101111), C(0b11111111) };
+    constexpr char data[] = {
+        flags[1], flags[0],                                     // flags
+        '\x12', '\x34',                                         // bodyFatPercentage
+        '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
+        '\x2A',                                                 // userID
+        '\x23', '\x45',                                         // basalMetabolism
+        '\x34', '\x56',                                         // musclePercentage
+        '\x45', '\x67',                                         // muscleMass
+        '\x56', '\x78',                                         // fatFreeMass
+        '\x67', '\x89',                                         // softLeanMass
+        '\x78', '\x9A',                                         // bodyWaterMass
+        '\x89', '\xAB',                                         // impedance
+        '\x9A', '\xBC',                                         // weight
+        '\xAB', '\xCD'                                          // height
+    };
+
+    auto result = bleValueParser.make_value<BodyCompositionMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isMeasurementUnsuccessful());
+    EXPECT_EQ(MeasurementUnitsEnum::Imperial, result->measurementUnits());
+    EXPECT_TRUE(result->isTimeStampPresent());
+    EXPECT_TRUE(result->isUserIDPresent());
+    EXPECT_TRUE(result->isBasalMetabolismPresent());
+    EXPECT_TRUE(result->isMusclePercentagePresent());
+    EXPECT_TRUE(result->isMuscleMassPresent());
+    EXPECT_TRUE(result->isFatFreeMassPresent());
+    EXPECT_TRUE(result->isSoftLeanMassPresent());
+    EXPECT_TRUE(result->isBodyWaterMassPresent());
+    EXPECT_TRUE(result->isImpedancePresent());
+    EXPECT_TRUE(result->isWeightPresent());
+    EXPECT_TRUE(result->isHeightPresent());
+    EXPECT_FALSE(result->isMultiplePacketMeasurement());
+    EXPECT_FLOAT_EQ(1333.0, result->bodyFatPercentage());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(02, result->month());
+    EXPECT_EQ(06, result->day());
+    EXPECT_EQ(18, result->hour());
+    EXPECT_EQ(28, result->minute());
+    EXPECT_EQ(00, result->seconds());
+    EXPECT_EQ(42, result->userID());
+    EXPECT_EQ(17699, result->basalMetabolism());
+    EXPECT_FLOAT_EQ(2206.8, result->musclePercentage());
+    EXPECT_FLOAT_EQ(264.37, result->muscleMass());
+    EXPECT_FLOAT_EQ(308.06, result->fatFreeMass());
+    EXPECT_FLOAT_EQ(351.75, result->softLeanMass());
+    EXPECT_FLOAT_EQ(395.44, result->bodyWaterMass());
+    EXPECT_FLOAT_EQ(4391.3, result->impedance());
+    EXPECT_FLOAT_EQ(482.81998, result->weight());
+    EXPECT_FLOAT_EQ(5265.1, result->height());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(45055, btSpecObj.flags);
+    EXPECT_EQ(0x3412, btSpecObj.bodyFatPercentage);
+    EXPECT_EQ(2023, btSpecObj.timeStamp.year);
+    EXPECT_EQ(02, btSpecObj.timeStamp.month);
+    EXPECT_EQ(06, btSpecObj.timeStamp.day);
+    EXPECT_EQ(18, btSpecObj.timeStamp.hour);
+    EXPECT_EQ(28, btSpecObj.timeStamp.minute);
+    EXPECT_EQ(00, btSpecObj.timeStamp.seconds);
+    EXPECT_EQ(42, btSpecObj.userID.userIndex);
+    EXPECT_EQ(0x4523, btSpecObj.basalMetabolism);
+    EXPECT_EQ(0x5634, btSpecObj.musclePercentage);
+    EXPECT_EQ(0x6745, btSpecObj.muscleMass);
+    EXPECT_EQ(0x7856, btSpecObj.fatFreeMass);
+    EXPECT_EQ(0x8967, btSpecObj.softLeanMass);
+    EXPECT_EQ(0x9A78, btSpecObj.bodyWaterMass);
+    EXPECT_EQ(0xAB89, btSpecObj.impedance);
+    EXPECT_EQ(0xBC9A, btSpecObj.weight);
+    EXPECT_EQ(0xCDAB, btSpecObj.height);
+
+    EXPECT_EQ("BodyFatPercentage: 1333%, TimeStamp: 06.02.2023 18:28:00, UserID: 42, BasalMetabolism: 17699kJ, MusclePercentage: 2206.8%, MuscleMass: 264.37lb, FatFreeMass: 308.06lb, SoftLeanMass: 351.75lb, BodyWaterMass: 395.44lb, Impedance: 4391.3Ω, Weight: 482.82lb, Height: 5265.1in", result->toString());
+}
+
+TEST_F(BodyCompositionMeasurementTest, ToString)
+{
+    //                             RRRMFFFF       FFFFFFFU
+    constexpr char flags[] = { C(0b10101111), C(0b11111110) };
+    constexpr char data[] = {
+        flags[1], flags[0],                                     // flags
+        '\x12', '\x34',                                         // bodyFatPercentage
+        '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
+        '\x2A',                                                 // userID
+        '\x23', '\x45',                                         // basalMetabolism
+        '\x34', '\x56',                                         // musclePercentage
+        '\x45', '\x67',                                         // muscleMass
+        '\x56', '\x78',                                         // fatFreeMass
+        '\x67', '\x89',                                         // softLeanMass
+        '\x78', '\x9A',                                         // bodyWaterMass
+        '\x89', '\xAB',                                         // impedance
+        '\x9A', '\xBC',                                         // weight
+        '\xAB', '\xCD'                                          // height
+    };
+
+    auto result = bleValueParser.make_value(CharacteristicType::BodyCompositionMeasurement,
+                                            data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+
+    EXPECT_EQ("BodyFatPercentage: 1333%, TimeStamp: 06.02.2023 18:28:00, UserID: 42, BasalMetabolism: 17699kJ, MusclePercentage: 2206.8%, MuscleMass: 132.185kg, FatFreeMass: 154.03kg, SoftLeanMass: 175.875kg, BodyWaterMass: 197.72kg, Impedance: 4391.3Ω, Weight: 241.41kg, Height: 52.651m", result->toString());
+}
+
+}  // namespace bvp

--- a/tests/bodysensorlocationtest.cpp
+++ b/tests/bodysensorlocationtest.cpp
@@ -23,6 +23,7 @@ TEST_F(BodySensorLocationTest, Other)
     constexpr char data[] = { '\x00' };
 
     auto result = bleValueParser.make_value<BodySensorLocation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(BodySensorLocationEnum::Other, result->location());
 
@@ -37,6 +38,7 @@ TEST_F(BodySensorLocationTest, Chest)
     constexpr char data[] = { '\x01' };
 
     auto result = bleValueParser.make_value<BodySensorLocation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(BodySensorLocationEnum::Chest, result->location());
 
@@ -51,6 +53,7 @@ TEST_F(BodySensorLocationTest, Wrist)
     constexpr char data[] = { '\x02' };
 
     auto result = bleValueParser.make_value<BodySensorLocation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(BodySensorLocationEnum::Wrist, result->location());
 
@@ -65,6 +68,7 @@ TEST_F(BodySensorLocationTest, Finger)
     constexpr char data[] = { '\x03' };
 
     auto result = bleValueParser.make_value<BodySensorLocation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(BodySensorLocationEnum::Finger, result->location());
 
@@ -79,6 +83,7 @@ TEST_F(BodySensorLocationTest, Hand)
     constexpr char data[] = { '\x04' };
 
     auto result = bleValueParser.make_value<BodySensorLocation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(BodySensorLocationEnum::Hand, result->location());
 
@@ -93,6 +98,7 @@ TEST_F(BodySensorLocationTest, EarLobe)
     constexpr char data[] = { '\x05' };
 
     auto result = bleValueParser.make_value<BodySensorLocation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(BodySensorLocationEnum::EarLobe, result->location());
 
@@ -107,6 +113,7 @@ TEST_F(BodySensorLocationTest, Foot)
     constexpr char data[] = { '\x06' };
 
     auto result = bleValueParser.make_value<BodySensorLocation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(BodySensorLocationEnum::Foot, result->location());
 
@@ -121,6 +128,7 @@ TEST_F(BodySensorLocationTest, Unknown)
     constexpr char data[] = { '\x07' };
 
     auto result = bleValueParser.make_value<BodySensorLocation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(BodySensorLocationEnum::Unknown, result->location());
 
@@ -135,6 +143,7 @@ TEST_F(BodySensorLocationTest, Empty)
     constexpr char data[] = {};
 
     auto result = bleValueParser.make_value<BodySensorLocation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_FALSE(result->isValid());
     EXPECT_EQ(BodySensorLocationEnum::Unknown, result->location());
 
@@ -149,6 +158,7 @@ TEST_F(BodySensorLocationTest, InvalidSize)
     constexpr char data[] = { '\x01', '\x02' };
 
     auto result = bleValueParser.make_value<BodySensorLocation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_FALSE(result->isValid());
     EXPECT_EQ(BodySensorLocationEnum::Unknown, result->location());
 

--- a/tests/currenttimetest.cpp
+++ b/tests/currenttimetest.cpp
@@ -23,6 +23,7 @@ TEST_F(CurrentTimeTest, Manual_255)
     constexpr char data[] = { '\xE7', '\x07', '\x01', '\x02', '\x14', '\x16', '\x07', '\x01', '\xFF', '\01' };
 
     auto result = bleValueParser.make_value<CurrentTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(2023, result->year());
     EXPECT_EQ(1, result->month());
@@ -48,7 +49,7 @@ TEST_F(CurrentTimeTest, Manual_255)
     EXPECT_EQ(DayOfWeekEnum::Monday, btSpecObj.exactTime256.dayDateTime.dayOfWeek.dayOfWeek);
     EXPECT_EQ(255, btSpecObj.exactTime256.fractions256);
 
-    EXPECT_EQ("Mon 02.01.2023 20:22:07.996 (adjust reason: ManuallyAdjusted )", result->toString());
+    EXPECT_EQ("Mon 02.01.2023 20:22:07.996 (adjust reason: { ManuallyAdjusted })", result->toString());
 }
 
 TEST_F(CurrentTimeTest, External_0)
@@ -56,6 +57,7 @@ TEST_F(CurrentTimeTest, External_0)
     constexpr char data[] = { '\xE7', '\x07', '\x01', '\x03', '\x14', '\x16', '\x07', '\x02', '\x00', '\02' };
 
     auto result = bleValueParser.make_value<CurrentTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(2023, result->year());
     EXPECT_EQ(1, result->month());
@@ -81,7 +83,7 @@ TEST_F(CurrentTimeTest, External_0)
     EXPECT_EQ(DayOfWeekEnum::Tuesday, btSpecObj.exactTime256.dayDateTime.dayOfWeek.dayOfWeek);
     EXPECT_EQ(0, btSpecObj.exactTime256.fractions256);
 
-    EXPECT_EQ("Tue 03.01.2023 20:22:07.000 (adjust reason: ExternalReference )", result->toString());
+    EXPECT_EQ("Tue 03.01.2023 20:22:07.000 (adjust reason: { ExternalReference })", result->toString());
 }
 
 TEST_F(CurrentTimeTest, TZChanged_1)
@@ -89,6 +91,7 @@ TEST_F(CurrentTimeTest, TZChanged_1)
     constexpr char data[] = { '\xE7', '\x07', '\x01', '\x04', '\x14', '\x16', '\x07', '\x03', '\x01', '\04' };
 
     auto result = bleValueParser.make_value<CurrentTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(2023, result->year());
     EXPECT_EQ(1, result->month());
@@ -114,7 +117,7 @@ TEST_F(CurrentTimeTest, TZChanged_1)
     EXPECT_EQ(DayOfWeekEnum::Wednesday, btSpecObj.exactTime256.dayDateTime.dayOfWeek.dayOfWeek);
     EXPECT_EQ(1, btSpecObj.exactTime256.fractions256);
 
-    EXPECT_EQ("Wed 04.01.2023 20:22:07.003 (adjust reason: TZChanged )", result->toString());
+    EXPECT_EQ("Wed 04.01.2023 20:22:07.003 (adjust reason: { TZChanged })", result->toString());
 }
 
 TEST_F(CurrentTimeTest, DSTChanged_128)
@@ -122,6 +125,7 @@ TEST_F(CurrentTimeTest, DSTChanged_128)
     constexpr char data[] = { '\xE7', '\x07', '\x01', '\x05', '\x14', '\x16', '\x07', '\x04', '\x80', '\x08' };
 
     auto result = bleValueParser.make_value<CurrentTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(2023, result->year());
     EXPECT_EQ(1, result->month());
@@ -147,7 +151,7 @@ TEST_F(CurrentTimeTest, DSTChanged_128)
     EXPECT_EQ(DayOfWeekEnum::Thursday, btSpecObj.exactTime256.dayDateTime.dayOfWeek.dayOfWeek);
     EXPECT_EQ(128, btSpecObj.exactTime256.fractions256);
 
-    EXPECT_EQ("Thu 05.01.2023 20:22:07.500 (adjust reason: DSTChanged )", result->toString());
+    EXPECT_EQ("Thu 05.01.2023 20:22:07.500 (adjust reason: { DSTChanged })", result->toString());
 }
 
 TEST_F(CurrentTimeTest, Friday)
@@ -155,6 +159,7 @@ TEST_F(CurrentTimeTest, Friday)
     constexpr char data[] = { '\xE6', '\x07', '\x0C', '\x1D', '\x17', '\x3B', '\x3B', '\x05', '\xFF', '\x01' };
 
     auto result = bleValueParser.make_value<CurrentTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(2022, result->year());
     EXPECT_EQ(12, result->month());
@@ -180,7 +185,7 @@ TEST_F(CurrentTimeTest, Friday)
     EXPECT_EQ(DayOfWeekEnum::Friday, btSpecObj.exactTime256.dayDateTime.dayOfWeek.dayOfWeek);
     EXPECT_EQ(255, btSpecObj.exactTime256.fractions256);
 
-    EXPECT_EQ("Fri 29.12.2022 23:59:59.996 (adjust reason: ManuallyAdjusted )", result->toString());
+    EXPECT_EQ("Fri 29.12.2022 23:59:59.996 (adjust reason: { ManuallyAdjusted })", result->toString());
 }
 
 TEST_F(CurrentTimeTest, Saturday)
@@ -188,6 +193,7 @@ TEST_F(CurrentTimeTest, Saturday)
     constexpr char data[] = { '\xE6', '\x07', '\x0C', '\x1E', '\x17', '\x3B', '\x3B', '\x06', '\xFF', '\x01' };
 
     auto result = bleValueParser.make_value<CurrentTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(2022, result->year());
     EXPECT_EQ(12, result->month());
@@ -213,7 +219,7 @@ TEST_F(CurrentTimeTest, Saturday)
     EXPECT_EQ(DayOfWeekEnum::Saturday, btSpecObj.exactTime256.dayDateTime.dayOfWeek.dayOfWeek);
     EXPECT_EQ(255, btSpecObj.exactTime256.fractions256);
 
-    EXPECT_EQ("Sat 30.12.2022 23:59:59.996 (adjust reason: ManuallyAdjusted )", result->toString());
+    EXPECT_EQ("Sat 30.12.2022 23:59:59.996 (adjust reason: { ManuallyAdjusted })", result->toString());
 }
 
 TEST_F(CurrentTimeTest, Sunday)
@@ -221,6 +227,7 @@ TEST_F(CurrentTimeTest, Sunday)
     constexpr char data[] = { '\xE6', '\x07', '\x0C', '\x1F', '\x17', '\x3B', '\x3B', '\x07', '\xFF', '\x01' };
 
     auto result = bleValueParser.make_value<CurrentTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(2022, result->year());
     EXPECT_EQ(12, result->month());
@@ -246,7 +253,7 @@ TEST_F(CurrentTimeTest, Sunday)
     EXPECT_EQ(DayOfWeekEnum::Sunday, btSpecObj.exactTime256.dayDateTime.dayOfWeek.dayOfWeek);
     EXPECT_EQ(255, btSpecObj.exactTime256.fractions256);
 
-    EXPECT_EQ("Sun 31.12.2022 23:59:59.996 (adjust reason: ManuallyAdjusted )", result->toString());
+    EXPECT_EQ("Sun 31.12.2022 23:59:59.996 (adjust reason: { ManuallyAdjusted })", result->toString());
 }
 
 TEST_F(CurrentTimeTest, TooShort)
@@ -254,6 +261,7 @@ TEST_F(CurrentTimeTest, TooShort)
     constexpr char data[] = { '\xE7', '\x07', '\x01', '\x04', '\x14', '\x16', '\x07', '\x03', '\x80' };
 
     auto result = bleValueParser.make_value<CurrentTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_FALSE(result->isValid());
 
     EXPECT_EQ("<Invalid>", result->toString());
@@ -264,6 +272,7 @@ TEST_F(CurrentTimeTest, TooLong)
     constexpr char data[] = { '\xE7', '\x07', '\x01', '\x04', '\x14', '\x16', '\x07', '\x03', '\x80', '\x08', '\x08' };
 
     auto result = bleValueParser.make_value<CurrentTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_FALSE(result->isValid());
 
     EXPECT_EQ("<Invalid>", result->toString());
@@ -274,9 +283,21 @@ TEST_F(CurrentTimeTest, InknownDayOfWeek)
     constexpr char data[] = { '\xE6', '\x07', '\x0C', '\x1F', '\x17', '\x3B', '\x3B', '\xAA', '\xFF', '\x01' };
 
     auto result = bleValueParser.make_value<CurrentTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
 
-    EXPECT_EQ("31.12.2022 23:59:59.996 (adjust reason: ManuallyAdjusted )", result->toString());
+    EXPECT_EQ("31.12.2022 23:59:59.996 (adjust reason: { ManuallyAdjusted })", result->toString());
+}
+
+TEST_F(CurrentTimeTest, NoReason)
+{
+    constexpr char data[] = { '\xE7', '\x07', '\x02', '\x06', '\x0E', '\x2F', '\x2A', '\x00', '\x00', '\x00' };
+
+    auto result = bleValueParser.make_value<CurrentTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+
+    EXPECT_EQ("06.02.2023 14:47:42.000", result->toString());
 }
 
 TEST_F(CurrentTimeTest, ToString)
@@ -288,7 +309,7 @@ TEST_F(CurrentTimeTest, ToString)
     EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
 
-    EXPECT_EQ("Sun 31.12.2022 23:59:59.996 (adjust reason: ManuallyAdjusted )", result->toString());
+    EXPECT_EQ("Sun 31.12.2022 23:59:59.996 (adjust reason: { ManuallyAdjusted })", result->toString());
 }
 
 }  // namespace bvp

--- a/tests/datetimetest.cpp
+++ b/tests/datetimetest.cpp
@@ -1,0 +1,80 @@
+#include "gtest/gtest.h"
+
+#include "blevalueparser.h"
+
+
+namespace bvp
+{
+
+class DateTimeTest : public testing::Test
+{
+protected:
+    explicit DateTimeTest() {}
+    virtual ~DateTimeTest() {}
+
+    BLEValueParser bleValueParser;
+
+//    virtual void SetUp() {}
+//    virtual void TearDown() {}
+};
+
+TEST_F(DateTimeTest, Normal)
+{
+    constexpr char data[] = { '\xE7', '\x07', '\x01', '\x02', '\x14', '\x16', '\x07' };
+
+    auto result = bleValueParser.make_value<DateTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(2023, result->year());
+    EXPECT_EQ(1, result->month());
+    EXPECT_EQ(2, result->day());
+    EXPECT_EQ(20, result->hour());
+    EXPECT_EQ(22, result->minute());
+    EXPECT_EQ(7, result->seconds());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(2023, btSpecObj.year);
+    EXPECT_EQ(1, btSpecObj.month);
+    EXPECT_EQ(2, btSpecObj.day);
+    EXPECT_EQ(20, btSpecObj.hour);
+    EXPECT_EQ(22, btSpecObj.minute);
+    EXPECT_EQ(7, btSpecObj.seconds);
+
+    EXPECT_EQ("02.01.2023 20:22:07", result->toString());
+}
+
+TEST_F(DateTimeTest, TooShort)
+{
+    constexpr char data[] = { '\xE7', '\x07', '\x01', '\x02', '\x14', '\x16' };
+
+    auto result = bleValueParser.make_value<DateTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(DateTimeTest, TooLong)
+{
+    constexpr char data[] = { '\xE7', '\x07', '\x01', '\x02', '\x14', '\x16', '\x07', '\x07' };
+
+    auto result = bleValueParser.make_value<DateTime>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(DateTimeTest, ToString)
+{
+    constexpr char data[] = { '\xE6', '\x07', '\x0C', '\x1F', '\x17', '\x3B', '\x3B' };
+
+    auto result = bleValueParser.make_value(CharacteristicType::DateTime,
+                                            data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+
+    EXPECT_EQ("31.12.2022 23:59:59", result->toString());
+}
+
+}  // namespace bvp

--- a/tests/heartratemeasurementtest.cpp
+++ b/tests/heartratemeasurementtest.cpp
@@ -24,6 +24,7 @@ TEST_F(HeartRateMeasurementTest, ContactsSupportedNotConnected)
     constexpr char data[] = { flags, '\xAA' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_TRUE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -46,6 +47,7 @@ TEST_F(HeartRateMeasurementTest, ContactsSupportedConnected)
     constexpr char data[] = { flags, '\xAA' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_TRUE(result->isContactSupported());
     EXPECT_TRUE(result->isContacted());
@@ -68,6 +70,7 @@ TEST_F(HeartRateMeasurementTest, HR8)
     constexpr char data[] = { flags, '\xAA' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_FALSE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -90,6 +93,7 @@ TEST_F(HeartRateMeasurementTest, HR16)
     constexpr char data[] = { flags, '\xAA', '\x01' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_FALSE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -112,6 +116,7 @@ TEST_F(HeartRateMeasurementTest, HR8_EE)
     constexpr char data[] = { flags, '\xAA', '\xBB', '\x01' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_FALSE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -135,6 +140,7 @@ TEST_F(HeartRateMeasurementTest, HR16_EE)
     constexpr char data[] = { flags, '\xAA', '\x01', '\xBB', '\x01' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_FALSE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -158,6 +164,7 @@ TEST_F(HeartRateMeasurementTest, HR8_EE_RR1)
     constexpr char data[] = { flags, '\xAA', '\xBB', '\x01', '\xCC', '\x01' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_FALSE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -185,6 +192,7 @@ TEST_F(HeartRateMeasurementTest, HR8_RR9)
     constexpr char data[] = { flags, '\xAA', '\x00', '\x00', '\x01', '\x00', '\x02', '\x00', '\x03', '\x00', '\xF3', '\x03', '\xFC', '\xFF', '\xFD', '\xFF', '\xFE', '\xFF', '\xFF', '\xFF' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_FALSE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -228,6 +236,7 @@ TEST_F(HeartRateMeasurementTest, HR8_RR10)
     constexpr char data[] = { flags, '\xAA', '\xA1', '\x01', '\xA2', '\x01', '\xA3', '\x01', '\xA4', '\x01', '\xA5', '\x01', '\xA6', '\x01', '\xA7', '\x01', '\xA8', '\x01', '\xA9', '\x01' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_FALSE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -270,6 +279,7 @@ TEST_F(HeartRateMeasurementTest, HR8_EE_RR8)
     constexpr char data[] = { flags, '\xAA', '\xBB', '\x01', '\xA1', '\x01', '\xA2', '\x01', '\xA3', '\x01', '\xA4', '\x01', '\xA5', '\x01', '\xA6', '\x01', '\xA7', '\x01', '\xA8', '\x01' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_FALSE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -312,6 +322,7 @@ TEST_F(HeartRateMeasurementTest, HR8_EE_RR9)
     constexpr char data[] = { flags, '\xAA', '\xBB', '\x01', '\xA1', '\x01', '\xA2', '\x01', '\xA3', '\x01', '\xA4', '\x01', '\xA5', '\x01', '\xA6', '\x01', '\xA7', '\x01', '\xA8', '\x01' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_FALSE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -353,6 +364,7 @@ TEST_F(HeartRateMeasurementTest, HR16_RR8)
     constexpr char data[] = { flags, '\xAA', '\x01', '\xA1', '\x01', '\xA2', '\x01', '\xA3', '\x01', '\xA4', '\x01', '\xA5', '\x01', '\xA6', '\x01', '\xA7', '\x01', '\xA8', '\x01' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_FALSE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -394,6 +406,7 @@ TEST_F(HeartRateMeasurementTest, HR16_RR9)
     constexpr char data[] = { flags, '\xAA', '\x01', '\xA1', '\x01', '\xA2', '\x01', '\xA3', '\x01', '\xA4', '\x01', '\xA5', '\x01', '\xA6', '\x01', '\xA7', '\x01', '\xA8', '\x01' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_FALSE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -434,6 +447,7 @@ TEST_F(HeartRateMeasurementTest, HR16_EE_RR7)
     constexpr char data[] = { flags, '\xAA', '\x01', '\xBB', '\x01', '\xA1', '\x01', '\xA2', '\x01', '\xA3', '\x01', '\xA4', '\x01', '\xA5', '\x01', '\xA6', '\x01', '\xA7', '\x01' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_FALSE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -474,6 +488,7 @@ TEST_F(HeartRateMeasurementTest, HR16_EE_RR8)
     constexpr char data[] = { flags, '\xAA', '\x01', '\xBB', '\x01', '\xA1', '\x01', '\xA2', '\x01', '\xA3', '\x01', '\xA4', '\x01', '\xA5', '\x01', '\xA6', '\x01', '\xA7', '\x01' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_FALSE(result->isContactSupported());
     EXPECT_FALSE(result->isContacted());
@@ -513,6 +528,7 @@ TEST_F(HeartRateMeasurementTest, TooShort)
     constexpr char data[] = { flags };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_FALSE(result->isValid());
 
     EXPECT_EQ("<Invalid>", result->toString());
@@ -524,6 +540,7 @@ TEST_F(HeartRateMeasurementTest, TooLong)
     constexpr char data[] = { flags, '\xAA', '\x01', '\xBB', '\x01', '\xA1', '\x01', '\xA2', '\x01', '\xA3', '\x01', '\xA4', '\x01', '\xA5', '\x01', '\xA6', '\x01', '\xA7', '\x01', '\xA8', '\x01' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_FALSE(result->isValid());
 
     EXPECT_EQ("<Invalid>", result->toString());
@@ -535,6 +552,7 @@ TEST_F(HeartRateMeasurementTest, BrokenPacket)
     constexpr char data[] = { flags, '\xAA' };
 
     auto result = bleValueParser.make_value<HeartRateMeasurement>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_FALSE(result->isValid());
 
     EXPECT_EQ("<Invalid>", result->toString());

--- a/tests/hexstringtest.cpp
+++ b/tests/hexstringtest.cpp
@@ -23,6 +23,7 @@ TEST_F(HexStringTest, Basic)
     constexpr char data[] = { '\x01', '\x02', '\x03', '\x0D', '\x0E', '\x0F' };
 
     auto result = bleValueParser.make_value<HexString>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
 
     EXPECT_EQ("0x 01:02:03:0D:0E:0F", result->toString());
@@ -33,6 +34,7 @@ TEST_F(HexStringTest, Empty)
     constexpr char data[] = {};
 
     auto result = bleValueParser.make_value<HexString>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
 
     EXPECT_EQ("0x", result->toString());
@@ -54,10 +56,10 @@ TEST_F(HexStringTest, Configuration)
 {
     constexpr char data[] = { '\x01', '\x02', '\x03', '\x0D', '\x0E', '\x0F' };
 
-    bleValueParser.setStringPrefix("<< ");
-    bleValueParser.setStringSuffix(" >>");
-    bleValueParser.setHexPrefix("hex> ");
-    bleValueParser.setHexSeparator(" ");
+    bleValueParser.configuration.stringPrefix = "<< ";
+    bleValueParser.configuration.stringSuffix = " >>";
+    bleValueParser.configuration.hexPrefix = "hex> ";
+    bleValueParser.configuration.hexSeparator = " ";
 
     auto result = bleValueParser.make_value(CharacteristicType::SystemID,
                                             data, sizeof(data));

--- a/tests/internalparsertest.cpp
+++ b/tests/internalparsertest.cpp
@@ -6,6 +6,22 @@
 namespace bvp
 {
 
+TEST(InternalParserTest, Raw)
+{
+    constexpr char data[] = { 'a', 'b', 'c', 'X', 'Y', 'Z' };
+    BaseValue::Parser parser{data, sizeof(data)};
+    parser.parseInt16();
+    size_t size = 3;
+    EXPECT_EQ("cXY", std::string(parser.getRawData(size), size));
+}
+
+TEST(InternalParserTest, String)
+{
+    constexpr char data[] = { 'a', 'b', 'c', 'X', 'Y', 'Z' };
+    BaseValue::Parser parser{data, sizeof(data)};
+    EXPECT_EQ("abcXYZ", parser.parseString());
+}
+
 TEST(InternalParserTest, UInt8)
 {
     constexpr char data[] = { '\x00', '\x7F', '\x80', '\xFF' };
@@ -104,11 +120,29 @@ TEST(InternalParserTest, Int64)
     EXPECT_EQ(-1, parser.parseInt64());
 }
 
-TEST(InternalParserTest, String)
+TEST(InternalParserTest, Raw_OutOfData)
 {
     constexpr char data[] = { 'a', 'b', 'c', 'X', 'Y', 'Z' };
     BaseValue::Parser parser{data, sizeof(data)};
-    EXPECT_EQ("abcXYZ", parser.parseString());
+    parser.parseInt16();
+    EXPECT_FALSE(parser.outOfData());
+    size_t size = 5;
+    parser.getRawData(size);
+    EXPECT_TRUE(parser.outOfData());
+}
+
+TEST(InternalParserTest, Int_OutOfData)
+{
+    constexpr char data[] = { '\x00', '\x7F', '\x80', '\xFF' };
+    BaseValue::Parser parser{data, sizeof(data) - 1};
+    EXPECT_EQ(0, parser.parseInt8());
+    EXPECT_FALSE(parser.outOfData());
+    EXPECT_EQ(INT8_MAX, parser.parseInt8());
+    EXPECT_FALSE(parser.outOfData());
+    EXPECT_EQ(INT8_MIN, parser.parseInt8());
+    EXPECT_FALSE(parser.outOfData());
+    parser.parseInt8();
+    EXPECT_TRUE(parser.outOfData());
 }
 
 }  // namespace bvp

--- a/tests/localtimeinformationtest.cpp
+++ b/tests/localtimeinformationtest.cpp
@@ -23,6 +23,7 @@ TEST_F(LocalTimeInformationTest, TZUnknown_DSTUnknown)
     constexpr char data[] = { char(-128), '\xFF' };
 
     auto result = bleValueParser.make_value<LocalTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(TimeZoneEnum::Unknown, result->timeZone());
     EXPECT_EQ(DSTOffsetEnum::Unknown, result->dstOffset());
@@ -39,6 +40,7 @@ TEST_F(LocalTimeInformationTest, TZUnreal_DSTUnreal)
     constexpr char data[] = { 57, '\x2A' };
 
     auto result = bleValueParser.make_value<LocalTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(TimeZoneEnum::Unknown, result->timeZone());
     EXPECT_EQ(DSTOffsetEnum::Unknown, result->dstOffset());
@@ -55,6 +57,7 @@ TEST_F(LocalTimeInformationTest, TZPlus0_DST1h)
     constexpr char data[] = { '\x00', '\x04' };
 
     auto result = bleValueParser.make_value<LocalTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(TimeZoneEnum::Plus0, result->timeZone());
     EXPECT_EQ(DSTOffsetEnum::DaylightTime1h, result->dstOffset());
@@ -71,6 +74,7 @@ TEST_F(LocalTimeInformationTest, TZMinus48_DST0_5h)
     constexpr char data[] = { '\xD0', '\x02' };
 
     auto result = bleValueParser.make_value<LocalTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(TimeZoneEnum::Minus48, result->timeZone());
     EXPECT_EQ(DSTOffsetEnum::HalfAnHourDaylightTime0_5h, result->dstOffset());
@@ -87,6 +91,7 @@ TEST_F(LocalTimeInformationTest, TZPlus56_DST0)
     constexpr char data[] = { '\x38', '\x00' };
 
     auto result = bleValueParser.make_value<LocalTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(TimeZoneEnum::Plus56, result->timeZone());
     EXPECT_EQ(DSTOffsetEnum::StandardTime, result->dstOffset());

--- a/tests/pnpidtest.cpp
+++ b/tests/pnpidtest.cpp
@@ -23,6 +23,7 @@ TEST_F(PnPIDTest, Unknown)
     constexpr char data[] = { '\x2A', '\x12', '\x00', '\x23', '\x01', '\xBC', '\xAA' };
 
     auto result = bleValueParser.make_value<PnPID>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(VendorIdSourceEnum::Unknown, result->vendorIdSource());
     EXPECT_EQ(0x0012, result->vendorId());
@@ -45,6 +46,7 @@ TEST_F(PnPIDTest, BT)
     constexpr char data[] = { '\x01', '\x12', '\x00', '\x23', '\x01', '\xBC', '\xAA' };
 
     auto result = bleValueParser.make_value<PnPID>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(VendorIdSourceEnum::Bluetooth, result->vendorIdSource());
     EXPECT_EQ(0x0012, result->vendorId());
@@ -67,6 +69,7 @@ TEST_F(PnPIDTest, USB)
     constexpr char data[] = { '\x02', '\x12', '\x00', '\x23', '\x01', '\xBC', '\xAA' };
 
     auto result = bleValueParser.make_value<PnPID>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
     EXPECT_EQ(VendorIdSourceEnum::USB, result->vendorIdSource());
     EXPECT_EQ(0x0012, result->vendorId());
@@ -89,6 +92,7 @@ TEST_F(PnPIDTest, TooShort)
     constexpr char data[] = { '\x01', '\x02', '\x03', '\x04', '\x05', '\x06' };
 
     auto result = bleValueParser.make_value<PnPID>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_FALSE(result->isValid());
 
     EXPECT_EQ("<Invalid>", result->toString());
@@ -99,6 +103,7 @@ TEST_F(PnPIDTest, TooLong)
     constexpr char data[] = { '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07', '\x08' };
 
     auto result = bleValueParser.make_value<PnPID>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_FALSE(result->isValid());
 
     EXPECT_EQ("<Invalid>", result->toString());

--- a/tests/textstringtest.cpp
+++ b/tests/textstringtest.cpp
@@ -23,6 +23,7 @@ TEST_F(TextStringTest, Basic)
     constexpr char data[] = { 'a', 'B', 'c', 'X', 'y', 'Z' };
 
     auto result = bleValueParser.make_value<TextString>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
 
     EXPECT_EQ("aBcXyZ", result->toString());
@@ -33,6 +34,7 @@ TEST_F(TextStringTest, Empty)
     constexpr char data[] = {};
 
     auto result = bleValueParser.make_value<TextString>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
 
     EXPECT_EQ("", result->toString());

--- a/tests/unsupportedtest.cpp
+++ b/tests/unsupportedtest.cpp
@@ -23,7 +23,7 @@ TEST_F(UnsupportedTest, ToStringHex)
     constexpr char data[] = { '\x00', '\x01', '\x02', '\x03' };
 
     auto result = bleValueParser.make_value(CharacteristicType::RelativeRuntimeinaCorrelatedColorTemperatureRange,
-        data, sizeof(data));
+                                            data, sizeof(data));
     EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
 
@@ -35,7 +35,7 @@ TEST_F(UnsupportedTest, ToStringText)
     constexpr char data[] = { '\x30', '\x31', '\x32', '\x33' };
 
     auto result = bleValueParser.make_value(CharacteristicType::RelativeRuntimeinaCorrelatedColorTemperatureRange,
-        data, sizeof(data));
+                                            data, sizeof(data));
     EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
 

--- a/tests/userindextest.cpp
+++ b/tests/userindextest.cpp
@@ -1,0 +1,93 @@
+#include "gtest/gtest.h"
+
+#include "blevalueparser.h"
+
+
+namespace bvp
+{
+
+class UserIndexTest : public testing::Test
+{
+protected:
+    explicit UserIndexTest() {}
+    virtual ~UserIndexTest() {}
+
+    BLEValueParser bleValueParser;
+
+    //    virtual void SetUp() {}
+    //    virtual void TearDown() {}
+};
+
+TEST_F(UserIndexTest, Min)
+{
+    constexpr char data[] = { '\x00' };
+
+    auto result = bleValueParser.make_value<UserIndex>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(0, result->userIndex());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(0, btSpecObj.userIndex);
+
+    EXPECT_EQ("0", result->toString());
+}
+
+TEST_F(UserIndexTest, Valid42)
+{
+    constexpr char data[] = { '\x2A' };
+
+    auto result = bleValueParser.make_value<UserIndex>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(42, result->userIndex());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(42, btSpecObj.userIndex);
+
+    EXPECT_EQ("42", result->toString());
+}
+
+TEST_F(UserIndexTest, Max)
+{
+    constexpr char data[] = { '\xFE' };
+
+    auto result = bleValueParser.make_value<UserIndex>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(254, result->userIndex());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(254, btSpecObj.userIndex);
+
+    EXPECT_EQ("254", result->toString());
+}
+
+TEST_F(UserIndexTest, Unknown)
+{
+    constexpr char data[] = { '\xFF' };
+
+    auto result = bleValueParser.make_value<UserIndex>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(255, result->userIndex());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(255, btSpecObj.userIndex);
+
+    EXPECT_EQ("<Unknown User>", result->toString());
+}
+
+TEST_F(UserIndexTest, ToString)
+{
+    constexpr char data[] = { '\xFE' };
+
+    auto result = bleValueParser.make_value(CharacteristicType::UserIndex,
+                                            data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+
+    EXPECT_EQ("254", result->toString());
+}
+
+}  // namespace bvp


### PR DESCRIPTION
- added: implementation of `Body Composition Feature` characteristic from Bluetooth specification
- added: implementation of `Body Composition Measurement` characteristic from Bluetooth specification
- added: implementation of custom `Body Composition Measurement` characteristic for `Xiaomi Mi Body Composition Scale 2 (XMTZC05HM)`
- added: parsers for `Date Time` (reused by `Current Time` and `Body Composition Measurement`) and `User Index` characteristics
- changed: `Current Time` is refactored to reuse `Date Time` characteristic
- changed: in `Current Time` parser string representation of list of flags is unified
- added: `NoReason` test case for `Current Time` parser
- changed: refactored code of parsers configuration
- added: getter for raw data in internal `Parser`
- added: `Raw_OutOfData` and `Int_OutOfData` test cases for internal `Parser`
- added: checks for `nullptr` result of `make_value()` call in all test cases
- added: static `expectedSize()` method for characteristics with constant packet length
- changed: binary values for flag constants replaces by statements with bitshift operations
- added: constructors in characteristics classes to create instance from sctructure from Bluetooth specification (currently for internal use only)
- changed: `make_value()` is refactored to use `make_value<T>()`
- added: autodetection of device type in Demo App to use non-standard parsers
- added: ability to subscribe to characteristics with `indicate` flag in Demo App
- fixed: in some statements of Demo App code `auto` makes type unclear
- changed: used `const` where possible in Demo App code