### PR TITLE
Implemented Reference Time Information characteristic parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,10 @@ set(LIBRARY_SOURCES
     include/blevalueparser/hexstring.h
     include/blevalueparser/localtimeinformation.h
     include/blevalueparser/pnpid.h
+    include/blevalueparser/referencetimeinformation.h
     include/blevalueparser/textstring.h
+    include/blevalueparser/timeaccuracy.h
+    include/blevalueparser/timesource.h
     include/blevalueparser/userindex.h
 )
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # BLE Value Parser
 This is a header only library for parsing characteristics of some standardized BLE services. At the moment, parsers are implemented for the following services:
 * Device Information Service v1.1 (partially)
-* Current Time Service v1.1 (partially)
+* Current Time Service v1.1 (full)
 * Battery Service v1.1 (partially)
 * Heart Rate Service v1.0 (full)
 * Body Composition Service v1.0 (full, with additional custom parser for Xiaomi Mi Body Composition Scale 2)

--- a/include/blevalueparser/basevalue.h
+++ b/include/blevalueparser/basevalue.h
@@ -217,6 +217,11 @@ protected:
         }
     };
 
+    void create(Parser &parser)
+    {
+        m_isValid = parse(parser) && !parser.outOfData();
+    }
+
     void create(const char *data, size_t size)
     {
         if (!checkSize(size))
@@ -225,7 +230,7 @@ protected:
         }
 
         Parser parser{data, size};
-        m_isValid = parse(parser) && !parser.outOfData();
+        create(parser);
     }
 
     virtual bool checkSize(size_t size) = 0;

--- a/include/blevalueparser/batterylevel.h
+++ b/include/blevalueparser/batterylevel.h
@@ -34,6 +34,13 @@ public:
 
 private:
     friend class BLEValueParser;
+
+    explicit BatteryLevel(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
     explicit BatteryLevel(const char *data, size_t size, const Configuration &configuration) :
         BaseValue{configuration}
     {
@@ -49,14 +56,9 @@ private:
 
     BatteryLevelStruct m_batteryLevel;
 
-    static size_t expectedSize()
-    {
-        return 1;
-    }
-
     virtual bool checkSize(size_t size) override
     {
-        return size == expectedSize();
+        return size == 1;
     }
 
     virtual bool parse(Parser &parser) override

--- a/include/blevalueparser/bodycompositionfeature.h
+++ b/include/blevalueparser/bodycompositionfeature.h
@@ -201,6 +201,13 @@ public:
 
 private:
     friend class BLEValueParser;
+
+    explicit BodyCompositionFeature(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
     explicit BodyCompositionFeature(const char *data, size_t size, const Configuration &configuration) :
         BaseValue{configuration}
     {
@@ -216,14 +223,9 @@ private:
 
     BodyCompositionFeatureStruct m_bodyCompositionFeature;
 
-    static size_t expectedSize()
-    {
-        return 4;
-    }
-
     virtual bool checkSize(size_t size) override
     {
-        return size == expectedSize();
+        return size == 4;
     }
 
     virtual bool parse(Parser &parser) override

--- a/include/blevalueparser/bodycompositionmeasurement.h
+++ b/include/blevalueparser/bodycompositionmeasurement.h
@@ -19,6 +19,13 @@ class BodyCompositionMeasurement final : public BodyCompositionMeasurementBase
 {
 private:
     friend class BLEValueParser;
+
+    explicit BodyCompositionMeasurement(Parser &parser, const Configuration &configuration) :
+        BodyCompositionMeasurementBase{configuration}
+    {
+        create(parser);
+    }
+
     explicit BodyCompositionMeasurement(const char *data, size_t size, const Configuration &configuration) :
         BodyCompositionMeasurementBase{configuration}
     {
@@ -47,21 +54,13 @@ private:
         // 3.2.1.3 Time Stamp Field
         if (isTimeStampPresent())
         {
-            size_t dateTimeSize = DateTime::expectedSize();
-            const char *data = parser.getRawData(dateTimeSize);
-            assert(!parser.outOfData());
-            auto dateTime = DateTime(data, dateTimeSize, configuration);
-            m_bodyCompositionMeasurement.timeStamp = dateTime.getBtSpecObject();
+            m_bodyCompositionMeasurement.timeStamp = DateTime(parser, configuration).getBtSpecObject();
         }
 
         // 3.2.1.4 User ID Field
         if (isUserIDPresent())
         {
-            size_t userIDSize = UserIndex::expectedSize();
-            const char *data = parser.getRawData(userIDSize);
-            assert(!parser.outOfData());
-            auto userIndex = UserIndex(data, userIDSize, configuration);
-            m_bodyCompositionMeasurement.userID = userIndex.getBtSpecObject();
+            m_bodyCompositionMeasurement.userID = UserIndex(parser, configuration).getBtSpecObject();
         }
 
         // 3.2.1.5 Basal Metabolism

--- a/include/blevalueparser/bodycompositionmeasurementmibfs.h
+++ b/include/blevalueparser/bodycompositionmeasurementmibfs.h
@@ -36,6 +36,13 @@ public:
 
 private:
     friend class BLEValueParser;
+
+    explicit BodyCompositionMeasurementMIBFS(Parser &parser, const Configuration &configuration) :
+        BodyCompositionMeasurementBase{configuration}
+    {
+        create(parser);
+    }
+
     explicit BodyCompositionMeasurementMIBFS(const char *data, size_t size, const Configuration &configuration) :
         BodyCompositionMeasurementBase{configuration}
     {
@@ -56,11 +63,7 @@ private:
         // 3.2.1.3 Time Stamp Field
         if (isTimeStampPresent())
         {
-            size_t dateTimeSize = DateTime::expectedSize();
-            const char *data = parser.getRawData(dateTimeSize);
-            assert(!parser.outOfData());
-            auto dateTime = DateTime(data, dateTimeSize, configuration);
-            m_bodyCompositionMeasurement.timeStamp = dateTime.getBtSpecObject();
+            m_bodyCompositionMeasurement.timeStamp = DateTime(parser, configuration).getBtSpecObject();
         }
 
         // 3.2.1.11 Impedance

--- a/include/blevalueparser/bodysensorlocation.h
+++ b/include/blevalueparser/bodysensorlocation.h
@@ -48,6 +48,13 @@ public:
 
 private:
     friend class BLEValueParser;
+
+    explicit BodySensorLocation(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
     explicit BodySensorLocation(const char *data, size_t size, const Configuration &configuration) :
         BaseValue{configuration}
     {
@@ -63,14 +70,9 @@ private:
 
     BodySensorLocationStruct m_bodySensorLocation;
 
-    static size_t expectedSize()
-    {
-        return 1;
-    }
-
     virtual bool checkSize(size_t size) override
     {
-        return size == expectedSize();
+        return size == 1;
     }
 
     virtual bool parse(Parser &parser) override

--- a/include/blevalueparser/bvp.h
+++ b/include/blevalueparser/bvp.h
@@ -14,7 +14,10 @@
 #include "hexstring.h"
 #include "localtimeinformation.h"
 #include "pnpid.h"
+#include "referencetimeinformation.h"
 #include "textstring.h"
+#include "timeaccuracy.h"
+#include "timesource.h"
 #include "userindex.h"
 
 
@@ -37,6 +40,18 @@ public:
     {
         switch (characteristicType)
         {
+            // Unsorted
+            case CharacteristicType::DateTime:
+                return make_value<DateTime>(data, size);
+            case CharacteristicType::UserIndex:
+                return make_value<UserIndex>(data, size);
+            // 3.220 Time Accuracy
+            case CharacteristicType::TimeAccuracy:
+                return make_value<TimeAccuracy>(data, size);
+            // 3.228 Time Source
+            case CharacteristicType::TimeSource:
+                return make_value<TimeSource>(data, size);
+
             // Device Information Service (DIS_SPEC_V11r00.pdf)
             // 3.1 Manufacturer Name String
             case CharacteristicType::ManufacturerNameString:
@@ -76,8 +91,7 @@ public:
                 return make_value<LocalTimeInformation>(data, size);
             // 3.3 Reference Time Information
             case CharacteristicType::ReferenceTimeInformation:
-                // TODO:
-                break;
+                return make_value<ReferenceTimeInformation>(data, size);
 
             // Battery Service (BAS_V1.1.pdf)
             // 3.1 Battery Level
@@ -145,12 +159,6 @@ public:
             case CharacteristicType::BodyCompositionMeasurementMIBFS:
                 return make_value<BodyCompositionMeasurementMIBFS>(data, size);
 
-            // Unsorted
-            case CharacteristicType::DateTime:
-                return make_value<DateTime>(data, size);
-            case CharacteristicType::UserIndex:
-                return make_value<UserIndex>(data, size);
-
             // Other
             case CharacteristicType::DeviceName:
             case CharacteristicType::Appearance:
@@ -166,8 +174,6 @@ public:
             case CharacteristicType::DSTOffset:
             case CharacteristicType::TimeZone:
             case CharacteristicType::TimewithDST:
-            case CharacteristicType::TimeAccuracy:
-            case CharacteristicType::TimeSource:
             case CharacteristicType::TimeUpdateControlPoint:
             case CharacteristicType::TimeUpdateState:
             case CharacteristicType::GlucoseMeasurement:

--- a/include/blevalueparser/currenttime.h
+++ b/include/blevalueparser/currenttime.h
@@ -149,6 +149,13 @@ public:
 
 private:
     friend class BLEValueParser;
+
+    explicit CurrentTime(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
     explicit CurrentTime(const char *data, size_t size, const Configuration &configuration) :
         BaseValue{configuration}
     {
@@ -164,24 +171,15 @@ private:
 
     CurrentTimeStruct m_currentTime;
 
-    static size_t expectedSize()
-    {
-        return 10;
-    }
-
     virtual bool checkSize(size_t size) override
     {
-        return size == expectedSize();
+        return size == 10;
     }
 
     virtual bool parse(Parser &parser) override
     {
         // Exact Time 256
-        size_t dateTimeSize = DateTime::expectedSize();
-        const char *data = parser.getRawData(dateTimeSize);
-        assert(!parser.outOfData());
-        auto dateTime = DateTime(data, dateTimeSize, configuration);
-        m_currentTime.exactTime256.dayDateTime.dateTime = dateTime.getBtSpecObject();
+        m_currentTime.exactTime256.dayDateTime.dateTime = DateTime(parser, configuration).getBtSpecObject();
 
         m_currentTime.exactTime256.dayDateTime.dayOfWeek.dayOfWeek = DayOfWeekEnum(parser.parseUInt8());
         switch (m_currentTime.exactTime256.dayDateTime.dayOfWeek.dayOfWeek)

--- a/include/blevalueparser/datetime.h
+++ b/include/blevalueparser/datetime.h
@@ -70,6 +70,13 @@ public:
 
 private:
     friend class BLEValueParser;
+
+    explicit DateTime(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
     explicit DateTime(const char *data, size_t size, const Configuration &configuration) :
         BaseValue{configuration}
     {
@@ -85,14 +92,9 @@ private:
 
     DateTimeStruct m_dateTime;
 
-    static size_t expectedSize()
-    {
-        return 7;
-    }
-
     virtual bool checkSize(size_t size) override
     {
-        return size == expectedSize();
+        return size == 7;
     }
 
     virtual bool parse(Parser &parser) override

--- a/include/blevalueparser/heartratecontrolpoint.h
+++ b/include/blevalueparser/heartratecontrolpoint.h
@@ -42,6 +42,13 @@ public:
 
 private:
     friend class BLEValueParser;
+
+    explicit HeartRateControlPoint(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
     explicit HeartRateControlPoint(const char *data, size_t size, const Configuration &configuration) :
         BaseValue{configuration}
     {
@@ -57,14 +64,9 @@ private:
 
     HeartRateControlPointStruct m_heartRateControlPoint;
 
-    static size_t expectedSize()
-    {
-        return 1;
-    }
-
     virtual bool checkSize(size_t size) override
     {
-        return size == expectedSize();
+        return size == 1;
     }
 
     virtual bool parse(Parser &parser) override

--- a/include/blevalueparser/heartratemeasurement.h
+++ b/include/blevalueparser/heartratemeasurement.h
@@ -84,6 +84,13 @@ public:
 
 private:
     friend class BLEValueParser;
+
+    explicit HeartRateMeasurement(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
     explicit HeartRateMeasurement(const char *data, size_t size, const Configuration &configuration) :
         BaseValue{configuration}
     {

--- a/include/blevalueparser/hexstring.h
+++ b/include/blevalueparser/hexstring.h
@@ -18,6 +18,13 @@ public:
 
 private:
     friend class BLEValueParser;
+
+    explicit HexString(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
     explicit HexString(const char *data, size_t size, const Configuration &configuration) :
         BaseValue{configuration}
     {

--- a/include/blevalueparser/localtimeinformation.h
+++ b/include/blevalueparser/localtimeinformation.h
@@ -178,6 +178,13 @@ public:
 
 private:
     friend class BLEValueParser;
+
+    explicit LocalTimeInformation(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
     explicit LocalTimeInformation(const char *data, size_t size, const Configuration &configuration) :
         BaseValue{configuration}
     {
@@ -193,14 +200,9 @@ private:
 
     LocalTimeInformationStruct m_localTimeInformation;
 
-    static size_t expectedSize()
-    {
-        return 2;
-    }
-
     virtual bool checkSize(size_t size) override
     {
-        return size == expectedSize();
+        return size == 2;
     }
 
     virtual bool parse(Parser &parser) override

--- a/include/blevalueparser/pnpid.h
+++ b/include/blevalueparser/pnpid.h
@@ -81,6 +81,13 @@ public:
 
 private:
     friend class BLEValueParser;
+
+    explicit PnPID(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
     explicit PnPID(const char *data, size_t size, const Configuration &configuration) :
         BaseValue{configuration}
     {
@@ -96,14 +103,9 @@ private:
 
     PnPIDStruct m_pnpId;
 
-    static size_t expectedSize()
-    {
-        return 7;
-    }
-
     virtual bool checkSize(size_t size) override
     {
-        return size == expectedSize();
+        return size == 7;
     }
 
     virtual bool parse(Parser &parser) override

--- a/include/blevalueparser/referencetimeinformation.h
+++ b/include/blevalueparser/referencetimeinformation.h
@@ -1,0 +1,154 @@
+#pragma once
+
+#include "basevalue.h"
+#include "timesource.h"
+#include "timeaccuracy.h"
+
+
+namespace bvp
+{
+
+/*
+ * Current Time Service
+ * CTS_SPEC_V1.1.0.pdf
+ */
+
+// GATT_Specification_Supplement_v8.pdf
+// 3.178 Reference Time Information
+struct ReferenceTimeInformationStruct
+{
+    TimeSourceStruct timeSource;
+    TimeAccuracyStruct timeAccuracy;
+    uint8_t daysSinceUpdate = 0;
+    uint8_t hoursSinceUpdate = 0;
+};
+
+// 3.3 Reference Time Information
+class ReferenceTimeInformation final : public BaseValue
+{
+public:
+    ReferenceTimeInformationStruct getBtSpecObject() const
+    {
+        return m_referenceTimeInformation;
+    }
+
+    TimeSourceEnum timeSource() const
+    {
+        return m_referenceTimeInformation.timeSource.timeSource;
+    }
+
+    bool isTimeAccuracyLarger() const
+    {
+        return TimeAccuracy(m_referenceTimeInformation.timeAccuracy, configuration).isLarger();
+    }
+
+    bool isTimeAccuracyUnknown() const
+    {
+        return TimeAccuracy(m_referenceTimeInformation.timeAccuracy, configuration).isUnknown();
+    }
+
+    uint16_t timeAccuracyMs() const
+    {
+        return TimeAccuracy(m_referenceTimeInformation.timeAccuracy, configuration).accuracyMs();
+    }
+
+    uint8_t daysSinceUpdate() const
+    {
+        return m_referenceTimeInformation.daysSinceUpdate;
+    }
+
+    uint8_t hoursSinceUpdate() const
+    {
+        return m_referenceTimeInformation.hoursSinceUpdate;
+    }
+
+    bool isSinceUpdateGreater() const
+    {
+        return 255 == (daysSinceUpdate() & hoursSinceUpdate());
+    }
+
+    uint32_t timeSinceUpdateH() const
+    {
+        if (isSinceUpdateGreater())
+        {
+            return UINT32_MAX;
+        }
+
+        return m_referenceTimeInformation.daysSinceUpdate * 24 + m_referenceTimeInformation.hoursSinceUpdate;
+    }
+
+private:
+    friend class BLEValueParser;
+
+    explicit ReferenceTimeInformation(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
+    explicit ReferenceTimeInformation(const char *data, size_t size, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(data, size);
+    }
+
+    explicit ReferenceTimeInformation(const ReferenceTimeInformationStruct &btSpecObject, const Configuration &configuration) :
+        BaseValue{configuration},
+        m_referenceTimeInformation{btSpecObject}
+    {
+        m_isValid = true;
+    }
+
+    ReferenceTimeInformationStruct m_referenceTimeInformation;
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 4;
+    }
+
+    virtual bool parse(Parser &parser) override
+    {
+        // GATT_Specification_Supplement_v8.pdf
+        // 3.178 Reference Time Information
+        m_referenceTimeInformation.timeSource = TimeSource(parser, configuration).getBtSpecObject();
+        m_referenceTimeInformation.timeAccuracy = TimeAccuracy(parser, configuration).getBtSpecObject();
+        m_referenceTimeInformation.daysSinceUpdate = parser.parseUInt8();
+        m_referenceTimeInformation.hoursSinceUpdate = parser.parseUInt8();
+        if (255 != m_referenceTimeInformation.hoursSinceUpdate &&
+            23 < m_referenceTimeInformation.hoursSinceUpdate)
+        {
+            return false;
+        }
+
+        if ((255 == m_referenceTimeInformation.daysSinceUpdate &&
+             255 != m_referenceTimeInformation.hoursSinceUpdate) ||
+            (255 == m_referenceTimeInformation.hoursSinceUpdate &&
+             255 != m_referenceTimeInformation.daysSinceUpdate))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    virtual void toStringStream(std::stringstream &ss) const override
+    {
+        ss << "Src: " << TimeSource(m_referenceTimeInformation.timeSource, configuration);
+        ss << ", Drift: " << TimeAccuracy(m_referenceTimeInformation.timeAccuracy, configuration);
+
+        ss << ", Updated: ";
+        if (isSinceUpdateGreater())
+        {
+            ss << ">254days ago";
+            return;
+        }
+
+        if (m_referenceTimeInformation.daysSinceUpdate)
+        {
+            ss << static_cast<int>(m_referenceTimeInformation.daysSinceUpdate) << "days ";
+        }
+        ss << static_cast<int>(m_referenceTimeInformation.hoursSinceUpdate) << "hours ago";
+    }
+};
+
+}  // namespace bvp

--- a/include/blevalueparser/textstring.h
+++ b/include/blevalueparser/textstring.h
@@ -16,6 +16,13 @@ public:
 
 private:
     friend class BLEValueParser;
+
+    explicit TextString(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
     explicit TextString(const char *data, size_t size, const Configuration &configuration) :
         BaseValue{configuration}
     {

--- a/include/blevalueparser/timeaccuracy.h
+++ b/include/blevalueparser/timeaccuracy.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "basevalue.h"
+
+
+namespace bvp
+{
+
+// GATT_Specification_Supplement_v8.pdf
+// 3.220 Time Accuracy
+struct TimeAccuracyStruct
+{
+    uint8_t accuracy = 0;
+};
+
+class TimeAccuracy final : public BaseValue
+{
+public:
+    friend class ReferenceTimeInformation;
+
+    TimeAccuracyStruct getBtSpecObject() const
+    {
+        return m_timeAccuracy;
+    }
+
+    bool isLarger() const
+    {
+        // A value of 254 means drift is larger than 31.625s.
+        return m_timeAccuracy.accuracy == s_timeAccuracyLarge;
+    }
+
+    bool isUnknown() const
+    {
+        // A value of 255 means drift is unknown.
+        return m_timeAccuracy.accuracy == s_timeAccuracyUnknown;
+    }
+
+    uint16_t accuracyMs() const
+    {
+        if (m_timeAccuracy.accuracy >= s_timeAccuracyLarge)
+        {
+            return UINT16_MAX;
+        }
+
+        // This field represents accuracy (drift) of time information
+        // in steps of 1/8 of a second (125ms) compared to a reference time source.
+        return m_timeAccuracy.accuracy * 125;
+    }
+
+private:
+    friend class BLEValueParser;
+
+    explicit TimeAccuracy(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
+    explicit TimeAccuracy(const char *data, size_t size, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(data, size);
+    }
+
+    explicit TimeAccuracy(const TimeAccuracyStruct &btSpecObject, const Configuration &configuration) :
+        BaseValue{configuration},
+        m_timeAccuracy{btSpecObject}
+    {
+        m_isValid = true;
+    }
+
+    static constexpr uint8_t s_timeAccuracyLarge   = 254;
+    static constexpr uint8_t s_timeAccuracyUnknown = 255;
+
+    TimeAccuracyStruct m_timeAccuracy;
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 1;
+    }
+
+    virtual bool parse(Parser &parser) override
+    {
+        // 3.220 Time Accuracy
+        m_timeAccuracy.accuracy = parser.parseUInt8();
+
+        return true;
+    }
+
+    virtual void toStringStream(std::stringstream &ss) const override
+    {
+        if (isUnknown())
+        {
+            ss << "<Unknown>";
+            return;
+        }
+
+        if (isLarger())
+        {
+            ss << ">31625ms";
+            return;
+        }
+
+        ss << accuracyMs() << "ms";
+    }
+};
+
+}  // namespace bvp

--- a/include/blevalueparser/timesource.h
+++ b/include/blevalueparser/timesource.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include "basevalue.h"
+
+
+namespace bvp
+{
+
+// GATT_Specification_Supplement_v8.pdf
+// 3.228 Time Source (Table 3.341)
+enum class TimeSourceEnum : uint8_t
+{
+    Unknown             = 0,  // 7–255 - Reserved for Future Use
+    NetworkTimeProtocol = 1,
+    GPS                 = 2,
+    RadioTimeSignal     = 3,
+    Manual              = 4,
+    AtomicClock         = 5,
+    CellularNetwork     = 6,
+};
+
+// GATT_Specification_Supplement_v8.pdf
+// 3.228 Time Source
+struct TimeSourceStruct
+{
+    TimeSourceEnum timeSource = TimeSourceEnum::Unknown;
+};
+
+class TimeSource final : public BaseValue
+{
+public:
+    friend class ReferenceTimeInformation;
+
+    TimeSourceStruct getBtSpecObject() const
+    {
+        return m_timeSource;
+    }
+
+    TimeSourceEnum timeSource() const
+    {
+        return m_timeSource.timeSource;
+    }
+
+private:
+    friend class BLEValueParser;
+
+    explicit TimeSource(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
+    explicit TimeSource(const char *data, size_t size, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(data, size);
+    }
+
+    explicit TimeSource(const TimeSourceStruct &btSpecObject, const Configuration &configuration) :
+        BaseValue{configuration},
+        m_timeSource{btSpecObject}
+    {
+        m_isValid = true;
+    }
+
+    TimeSourceStruct m_timeSource;
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 1;
+    }
+
+    virtual bool parse(Parser &parser) override
+    {
+        // 3.228 Time Source
+        m_timeSource.timeSource = TimeSourceEnum(parser.parseUInt8());
+        switch (m_timeSource.timeSource)
+        {
+            case TimeSourceEnum::Unknown:
+            case TimeSourceEnum::NetworkTimeProtocol:
+            case TimeSourceEnum::GPS:
+            case TimeSourceEnum::RadioTimeSignal:
+            case TimeSourceEnum::Manual:
+            case TimeSourceEnum::AtomicClock:
+            case TimeSourceEnum::CellularNetwork:
+                break;
+            default:
+                m_timeSource.timeSource = TimeSourceEnum::Unknown;
+                break;
+        }
+
+        return true;
+    }
+
+    virtual void toStringStream(std::stringstream &ss) const override
+    {
+        switch (m_timeSource.timeSource)
+        {
+            case TimeSourceEnum::Unknown:
+                ss << "<Unknown>";
+                break;
+            case TimeSourceEnum::NetworkTimeProtocol:
+                ss << "NetworkTimeProtocol";
+                break;
+            case TimeSourceEnum::GPS:
+                ss << "GPS";
+                break;
+            case TimeSourceEnum::RadioTimeSignal:
+                ss << "RadioTimeSignal";
+                break;
+            case TimeSourceEnum::Manual:
+                ss << "Manual";
+                break;
+            case TimeSourceEnum::AtomicClock:
+                ss << "AtomicClock";
+                break;
+            case TimeSourceEnum::CellularNetwork:
+                ss << "CellularNetwork";
+                break;
+        }
+    }
+};
+
+}  // namespace bvp

--- a/include/blevalueparser/userindex.h
+++ b/include/blevalueparser/userindex.h
@@ -30,6 +30,13 @@ public:
 
 private:
     friend class BLEValueParser;
+
+    explicit UserIndex(Parser &parser, const Configuration &configuration) :
+        BaseValue{configuration}
+    {
+        create(parser);
+    }
+
     explicit UserIndex(const char *data, size_t size, const Configuration &configuration) :
         BaseValue{configuration}
     {
@@ -45,14 +52,9 @@ private:
 
     UserIndexStruct m_userIndex;
 
-    static size_t expectedSize()
-    {
-        return 1;
-    }
-
     virtual bool checkSize(size_t size) override
     {
-        return size == expectedSize();
+        return size == 1;
     }
 
     virtual bool parse(Parser &parser) override

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,10 @@ set(TEST_SOURCES
     internalparsertest.cpp
     localtimeinformationtest.cpp
     pnpidtest.cpp
+    referencetimeinformationtest.cpp
     textstringtest.cpp
+    timeaccuracytest.cpp
+    timesourcetest.cpp
     unsupportedtest.cpp
     userindextest.cpp
 )

--- a/tests/batteryleveltest.cpp
+++ b/tests/batteryleveltest.cpp
@@ -62,6 +62,26 @@ TEST_F(BatteryLevelTest, Unreal)
     EXPECT_EQ("<Invalid>", result->toString());
 }
 
+TEST_F(BatteryLevelTest, TooShort)
+{
+    auto result = bleValueParser.make_value<BatteryLevel>({}, 0);
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(BatteryLevelTest, TooLong)
+{
+    constexpr char data[] = { '\x2A', '\x2A' };
+
+    auto result = bleValueParser.make_value<BatteryLevel>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
 TEST_F(BatteryLevelTest, ToString)
 {
     constexpr char data[] = { '\x63' };

--- a/tests/bodysensorlocationtest.cpp
+++ b/tests/bodysensorlocationtest.cpp
@@ -138,30 +138,22 @@ TEST_F(BodySensorLocationTest, Unknown)
     EXPECT_EQ("<Unknown>", result->toString());
 }
 
-TEST_F(BodySensorLocationTest, Empty)
+TEST_F(BodySensorLocationTest, TooShort)
 {
     auto result = bleValueParser.make_value<BodySensorLocation>({}, 0);
     EXPECT_NE(nullptr, result);
     EXPECT_FALSE(result->isValid());
-    EXPECT_EQ(BodySensorLocationEnum::Unknown, result->location());
-
-    auto btSpecObj = result->getBtSpecObject();
-    EXPECT_EQ(BodySensorLocationEnum::Unknown, btSpecObj.bodySensorLocation);
 
     EXPECT_EQ("<Invalid>", result->toString());
 }
 
-TEST_F(BodySensorLocationTest, InvalidSize)
+TEST_F(BodySensorLocationTest, TooLong)
 {
     constexpr char data[] = { '\x01', '\x02' };
 
     auto result = bleValueParser.make_value<BodySensorLocation>(data, sizeof(data));
     EXPECT_NE(nullptr, result);
     EXPECT_FALSE(result->isValid());
-    EXPECT_EQ(BodySensorLocationEnum::Unknown, result->location());
-
-    auto btSpecObj = result->getBtSpecObject();
-    EXPECT_EQ(BodySensorLocationEnum::Unknown, btSpecObj.bodySensorLocation);
 
     EXPECT_EQ("<Invalid>", result->toString());
 }

--- a/tests/localtimeinformationtest.cpp
+++ b/tests/localtimeinformationtest.cpp
@@ -102,6 +102,29 @@ TEST_F(LocalTimeInformationTest, TZPlus56_DST0)
 
     EXPECT_EQ("TZ: 56, DST: Standard Time", result->toString());
 }
+
+TEST_F(LocalTimeInformationTest, TooShort)
+{
+    constexpr char data[] = { '\x2A' };
+
+    auto result = bleValueParser.make_value<LocalTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(LocalTimeInformationTest, TooLong)
+{
+    constexpr char data[] = { '\x2A', '\x2A', '\x2A' };
+
+    auto result = bleValueParser.make_value<LocalTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
 TEST_F(LocalTimeInformationTest, ToString)
 {
     constexpr char data[] = { char(-42), '\x08' };

--- a/tests/referencetimeinformationtest.cpp
+++ b/tests/referencetimeinformationtest.cpp
@@ -1,0 +1,200 @@
+#include <gtest/gtest.h>
+
+#include "blevalueparser/bvp.h"
+
+
+namespace bvp
+{
+
+class ReferenceTimeInformationTest : public testing::Test
+{
+protected:
+    explicit ReferenceTimeInformationTest() {}
+    virtual ~ReferenceTimeInformationTest() {}
+
+    BLEValueParser bleValueParser;
+
+//    virtual void SetUp() {}
+//    virtual void TearDown() {}
+};
+
+TEST_F(ReferenceTimeInformationTest, Unknown_0ms_0d_0h)
+{
+    constexpr char data[] = { '\x00', '\x00', '\x00', '\x00' };
+
+    auto result = bleValueParser.make_value<ReferenceTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::Unknown, result->timeSource());
+    EXPECT_EQ(0, result->timeAccuracyMs());
+    EXPECT_EQ(0, result->daysSinceUpdate());
+    EXPECT_EQ(0, result->hoursSinceUpdate());
+    EXPECT_EQ(0, result->timeSinceUpdateH());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::Unknown, btSpecObj.timeSource.timeSource);
+    EXPECT_EQ(0, btSpecObj.timeAccuracy.accuracy);
+    EXPECT_EQ(0, btSpecObj.daysSinceUpdate);
+    EXPECT_EQ(0, btSpecObj.hoursSinceUpdate);
+
+    EXPECT_EQ("Src: <Unknown>, Drift: 0ms, Updated: 0hours ago", result->toString());
+}
+
+TEST_F(ReferenceTimeInformationTest, GPS_5250ms_0d_23h)
+{
+    constexpr char data[] = { '\x02', '\x2A', '\x00', '\x17' };
+
+    auto result = bleValueParser.make_value<ReferenceTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::GPS, result->timeSource());
+    EXPECT_EQ(5250, result->timeAccuracyMs());
+    EXPECT_EQ(0, result->daysSinceUpdate());
+    EXPECT_EQ(23, result->hoursSinceUpdate());
+    EXPECT_EQ(23, result->timeSinceUpdateH());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::GPS, btSpecObj.timeSource.timeSource);
+    EXPECT_EQ(42, btSpecObj.timeAccuracy.accuracy);
+    EXPECT_EQ(0, btSpecObj.daysSinceUpdate);
+    EXPECT_EQ(23, btSpecObj.hoursSinceUpdate);
+
+    EXPECT_EQ("Src: GPS, Drift: 5250ms, Updated: 23hours ago", result->toString());
+}
+
+TEST_F(ReferenceTimeInformationTest, Manual_31625ms_254d_0h)
+{
+    constexpr char data[] = { '\x04', '\xFD', '\xFE', '\x00' };
+
+    auto result = bleValueParser.make_value<ReferenceTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::Manual, result->timeSource());
+    EXPECT_EQ(31625, result->timeAccuracyMs());
+    EXPECT_EQ(254, result->daysSinceUpdate());
+    EXPECT_EQ(0, result->hoursSinceUpdate());
+    EXPECT_EQ(6096, result->timeSinceUpdateH());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::Manual, btSpecObj.timeSource.timeSource);
+    EXPECT_EQ(253, btSpecObj.timeAccuracy.accuracy);
+    EXPECT_EQ(254, btSpecObj.daysSinceUpdate);
+    EXPECT_EQ(0, btSpecObj.hoursSinceUpdate);
+
+    EXPECT_EQ("Src: Manual, Drift: 31625ms, Updated: 254days 0hours ago", result->toString());
+}
+
+TEST_F(ReferenceTimeInformationTest, CellularNetwork_Greater_254d_23h)
+{
+    constexpr char data[] = { '\x06', '\xFE', '\xFE', '\x17' };
+
+    auto result = bleValueParser.make_value<ReferenceTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::CellularNetwork, result->timeSource());
+    EXPECT_EQ(UINT16_MAX, result->timeAccuracyMs());
+    EXPECT_EQ(254, result->daysSinceUpdate());
+    EXPECT_EQ(23, result->hoursSinceUpdate());
+    EXPECT_EQ(6119, result->timeSinceUpdateH());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::CellularNetwork, btSpecObj.timeSource.timeSource);
+    EXPECT_EQ(254, btSpecObj.timeAccuracy.accuracy);
+    EXPECT_EQ(254, btSpecObj.daysSinceUpdate);
+    EXPECT_EQ(23, btSpecObj.hoursSinceUpdate);
+
+    EXPECT_EQ("Src: CellularNetwork, Drift: >31625ms, Updated: 254days 23hours ago", result->toString());
+}
+
+TEST_F(ReferenceTimeInformationTest, Reserved_Unknown_Greater)
+{
+    constexpr char data[] = { '\xFF', '\xFF', '\xFF', '\xFF' };
+
+    auto result = bleValueParser.make_value<ReferenceTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::Unknown, result->timeSource());
+    EXPECT_FALSE(result->isTimeAccuracyLarger());
+    EXPECT_TRUE(result->isTimeAccuracyUnknown());
+    EXPECT_EQ(UINT16_MAX, result->timeAccuracyMs());
+    EXPECT_EQ(255, result->daysSinceUpdate());
+    EXPECT_EQ(255, result->hoursSinceUpdate());
+    EXPECT_EQ(UINT32_MAX, result->timeSinceUpdateH());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::Unknown, btSpecObj.timeSource.timeSource);
+    EXPECT_EQ(255, btSpecObj.timeAccuracy.accuracy);
+    EXPECT_EQ(255, btSpecObj.daysSinceUpdate);
+    EXPECT_EQ(255, btSpecObj.hoursSinceUpdate);
+
+    EXPECT_EQ("Src: <Unknown>, Drift: <Unknown>, Updated: >254days ago", result->toString());
+}
+
+TEST_F(ReferenceTimeInformationTest, InvalidHoursSinceUpdate)
+{
+    constexpr char data[] = { '\x2A', '\x2A', '\x2A', '\x18' };
+
+    auto result = bleValueParser.make_value<ReferenceTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(ReferenceTimeInformationTest, InvalidSinceUpdate1)
+{
+    constexpr char data[] = { '\x2A', '\x2A', '\xFF', '\x2A' };
+
+    auto result = bleValueParser.make_value<ReferenceTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(ReferenceTimeInformationTest, InvalidSinceUpdate2)
+{
+    constexpr char data[] = { '\x2A', '\x2A', '\x2A', '\xFF' };
+
+    auto result = bleValueParser.make_value<ReferenceTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(ReferenceTimeInformationTest, TooShort)
+{
+    constexpr char data[] = { '\x2A', '\x2A', '\x2A' };
+
+    auto result = bleValueParser.make_value<ReferenceTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(ReferenceTimeInformationTest, TooLong)
+{
+    constexpr char data[] = { '\x2A', '\x2A', '\x2A', '\x2A', '\x2A' };
+
+    auto result = bleValueParser.make_value<ReferenceTimeInformation>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(ReferenceTimeInformationTest, ToString)
+{
+    constexpr char data[] = { '\x01', '\xAA', '\x2A', '\x0F' };
+
+    auto result = bleValueParser.make_value(CharacteristicType::ReferenceTimeInformation,
+                                            data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+
+    EXPECT_EQ("Src: NetworkTimeProtocol, Drift: 21250ms, Updated: 42days 15hours ago", result->toString());
+}
+
+}  // namespace bvp

--- a/tests/timeaccuracytest.cpp
+++ b/tests/timeaccuracytest.cpp
@@ -1,0 +1,138 @@
+#include <gtest/gtest.h>
+
+#include "blevalueparser/bvp.h"
+
+
+namespace bvp
+{
+
+class TimeAccuracyTest : public testing::Test
+{
+protected:
+    explicit TimeAccuracyTest() {}
+    virtual ~TimeAccuracyTest() {}
+
+    BLEValueParser bleValueParser;
+
+//    virtual void SetUp() {}
+//    virtual void TearDown() {}
+};
+
+TEST_F(TimeAccuracyTest, Mininum)
+{
+    constexpr char data[] = { '\x00' };
+
+    auto result = bleValueParser.make_value<TimeAccuracy>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isLarger());
+    EXPECT_FALSE(result->isUnknown());
+    EXPECT_EQ(0, result->accuracyMs());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(0, btSpecObj.accuracy);
+
+    EXPECT_EQ("0ms", result->toString());
+}
+
+TEST_F(TimeAccuracyTest, Normal)
+{
+    constexpr char data[] = { '\x2A' };
+
+    auto result = bleValueParser.make_value<TimeAccuracy>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isLarger());
+    EXPECT_FALSE(result->isUnknown());
+    EXPECT_EQ(5250, result->accuracyMs());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(42, btSpecObj.accuracy);
+
+    EXPECT_EQ("5250ms", result->toString());
+}
+
+TEST_F(TimeAccuracyTest, Maximum)
+{
+    constexpr char data[] = { '\xFD' };
+
+    auto result = bleValueParser.make_value<TimeAccuracy>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isLarger());
+    EXPECT_FALSE(result->isUnknown());
+    EXPECT_EQ(31625, result->accuracyMs());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(253, btSpecObj.accuracy);
+
+    EXPECT_EQ("31625ms", result->toString());
+}
+
+TEST_F(TimeAccuracyTest, Larger)
+{
+    constexpr char data[] = { '\xFE' };
+
+    auto result = bleValueParser.make_value<TimeAccuracy>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_TRUE(result->isLarger());
+    EXPECT_FALSE(result->isUnknown());
+    EXPECT_EQ(UINT16_MAX, result->accuracyMs());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(254, btSpecObj.accuracy);
+
+    EXPECT_EQ(">31625ms", result->toString());
+}
+
+TEST_F(TimeAccuracyTest, Unknown)
+{
+    constexpr char data[] = { '\xFF' };
+
+    auto result = bleValueParser.make_value<TimeAccuracy>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_FALSE(result->isLarger());
+    EXPECT_TRUE(result->isUnknown());
+    EXPECT_EQ(UINT16_MAX, result->accuracyMs());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(255, btSpecObj.accuracy);
+
+    EXPECT_EQ("<Unknown>", result->toString());
+}
+
+TEST_F(TimeAccuracyTest, TooShort)
+{
+    auto result = bleValueParser.make_value<TimeAccuracy>({}, 0);
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(TimeAccuracyTest, TooLong)
+{
+    constexpr char data[] = { '\x2A', '\x2A' };
+
+    auto result = bleValueParser.make_value<TimeAccuracy>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(TimeAccuracyTest, ToString)
+{
+    constexpr char data[] = { '\x01' };
+
+    auto result = bleValueParser.make_value(CharacteristicType::TimeAccuracy,
+                                            data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+
+    EXPECT_EQ("125ms", result->toString());
+}
+
+}  // namespace bvp

--- a/tests/timesourcetest.cpp
+++ b/tests/timesourcetest.cpp
@@ -1,0 +1,188 @@
+#include <gtest/gtest.h>
+
+#include "blevalueparser/bvp.h"
+
+
+namespace bvp
+{
+
+class TimeSourceTest : public testing::Test
+{
+protected:
+    explicit TimeSourceTest() {}
+    virtual ~TimeSourceTest() {}
+
+    BLEValueParser bleValueParser;
+
+//    virtual void SetUp() {}
+//    virtual void TearDown() {}
+};
+
+TEST_F(TimeSourceTest, Unknown)
+{
+    constexpr char data[] = { '\x00' };
+
+    auto result = bleValueParser.make_value<TimeSource>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::Unknown, result->timeSource());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::Unknown, btSpecObj.timeSource);
+
+    EXPECT_EQ("<Unknown>", result->toString());
+}
+
+TEST_F(TimeSourceTest, NetworkTimeProtocol)
+{
+    constexpr char data[] = { '\x01' };
+
+    auto result = bleValueParser.make_value<TimeSource>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::NetworkTimeProtocol, result->timeSource());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::NetworkTimeProtocol, btSpecObj.timeSource);
+
+    EXPECT_EQ("NetworkTimeProtocol", result->toString());
+}
+
+TEST_F(TimeSourceTest, GPS)
+{
+    constexpr char data[] = { '\x02' };
+
+    auto result = bleValueParser.make_value<TimeSource>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::GPS, result->timeSource());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::GPS, btSpecObj.timeSource);
+
+    EXPECT_EQ("GPS", result->toString());
+}
+
+TEST_F(TimeSourceTest, RadioTimeSignal)
+{
+    constexpr char data[] = { '\x03' };
+
+    auto result = bleValueParser.make_value<TimeSource>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::RadioTimeSignal, result->timeSource());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::RadioTimeSignal, btSpecObj.timeSource);
+
+    EXPECT_EQ("RadioTimeSignal", result->toString());
+}
+
+TEST_F(TimeSourceTest, Manual)
+{
+    constexpr char data[] = { '\x04' };
+
+    auto result = bleValueParser.make_value<TimeSource>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::Manual, result->timeSource());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::Manual, btSpecObj.timeSource);
+
+    EXPECT_EQ("Manual", result->toString());
+}
+
+TEST_F(TimeSourceTest, AtomicClock)
+{
+    constexpr char data[] = { '\x05' };
+
+    auto result = bleValueParser.make_value<TimeSource>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::AtomicClock, result->timeSource());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::AtomicClock, btSpecObj.timeSource);
+
+    EXPECT_EQ("AtomicClock", result->toString());
+}
+
+TEST_F(TimeSourceTest, CellularNetwork)
+{
+    constexpr char data[] = { '\x06' };
+
+    auto result = bleValueParser.make_value<TimeSource>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::CellularNetwork, result->timeSource());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::CellularNetwork, btSpecObj.timeSource);
+
+    EXPECT_EQ("CellularNetwork", result->toString());
+}
+
+TEST_F(TimeSourceTest, Reserved)
+{
+    constexpr char data[] = { '\x07' };
+
+    auto result = bleValueParser.make_value<TimeSource>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::Unknown, result->timeSource());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::Unknown, btSpecObj.timeSource);
+
+    EXPECT_EQ("<Unknown>", result->toString());
+}
+
+TEST_F(TimeSourceTest, ReservedMax)
+{
+    constexpr char data[] = { '\xFF' };
+
+    auto result = bleValueParser.make_value<TimeSource>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+    EXPECT_EQ(TimeSourceEnum::Unknown, result->timeSource());
+
+    auto btSpecObj = result->getBtSpecObject();
+    EXPECT_EQ(TimeSourceEnum::Unknown, btSpecObj.timeSource);
+
+    EXPECT_EQ("<Unknown>", result->toString());
+}
+
+TEST_F(TimeSourceTest, TooShort)
+{
+    auto result = bleValueParser.make_value<TimeSource>({}, 0);
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(TimeSourceTest, TooLong)
+{
+    constexpr char data[] = { '\x2A', '\x2A' };
+
+    auto result = bleValueParser.make_value<TimeSource>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(TimeSourceTest, ToString)
+{
+    constexpr char data[] = { '\x01' };
+
+    auto result = bleValueParser.make_value(CharacteristicType::TimeSource,
+                                            data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_TRUE(result->isValid());
+
+    EXPECT_EQ("NetworkTimeProtocol", result->toString());
+}
+
+}  // namespace bvp

--- a/tests/userindextest.cpp
+++ b/tests/userindextest.cpp
@@ -78,6 +78,26 @@ TEST_F(UserIndexTest, Unknown)
     EXPECT_EQ("<Unknown User>", result->toString());
 }
 
+TEST_F(UserIndexTest, TooShort)
+{
+    auto result = bleValueParser.make_value<UserIndex>({}, 0);
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
+TEST_F(UserIndexTest, TooLong)
+{
+    constexpr char data[] = { '\x2A', '\x2A' };
+
+    auto result = bleValueParser.make_value<UserIndex>(data, sizeof(data));
+    EXPECT_NE(nullptr, result);
+    EXPECT_FALSE(result->isValid());
+
+    EXPECT_EQ("<Invalid>", result->toString());
+}
+
 TEST_F(UserIndexTest, ToString)
 {
     constexpr char data[] = { '\xFE' };


### PR DESCRIPTION
- added: Reference Time Information characteristic parser; now Current Time Service v1.1 is fully implemented
- added: Time Accuracy and Time Source characteristic parsers
- changed: simplified reuse of characteristics within other characteristics
- removed: `expectedSize()` static methods to unify characteristic classes for data with static and variable size
- added: `TooShort` & `TooLong` tests for Battery Level, Local Time Information, and User Index characteristics
- changed: `Empty` & `InvalidSize` tests for Body Sensor Location are renamed to `TooShort` & `TooLong` for unification