### PR TITLE
Parsers optimization

### DIFF
--- a/include/blevalueparser/alertcategoryid.h
+++ b/include/blevalueparser/alertcategoryid.h
@@ -89,13 +89,9 @@ public:
     friend class UnreadAlertStatus;
     friend class AlertNotificationControlPoint;
 
-    static AlertCategoryIDEnum categoryID(const AlertCategoryIDStruct &btSpecObject)
+    BVP_GETTER(AlertCategoryIDEnum, categoryID, AlertCategoryIDStruct)
     {
         return btSpecObject.categoryID;
-    }
-    AlertCategoryIDEnum categoryID() const
-    {
-        return categoryID(m_btSpecObject);
     }
 
 private:
@@ -106,17 +102,13 @@ private:
         return size == 1;
     }
 
-    static bool parse(Parser &parser, AlertCategoryIDStruct &btSpecObject)
+    BVP_PARSE(AlertCategoryIDStruct)
     {
         bool result{true};
 
         btSpecObject.categoryID %= AlertCategoryIDEnum(parser.parseUInt8());
 
         return result;
-    }
-    virtual bool parse(Parser &parser) override
-    {
-        return parse(parser, m_btSpecObject);
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/alertcategoryidbitmask.h
+++ b/include/blevalueparser/alertcategoryidbitmask.h
@@ -38,94 +38,54 @@ class AlertCategoryIDBitMask final : public BaseValueSpec<AlertCategoryIDBitMask
 public:
     friend class SupportedAlertCategoryBase;
 
-    static bool hasSimpleAlert(const AlertCategoryIDBitMaskStruct &btSpecObject)
+    BVP_GETTER(bool, hasSimpleAlert, AlertCategoryIDBitMaskStruct)
     {
         return (btSpecObject.categoryIDBitMask & ACI_FLAG_SIMPLE_ALERT) != 0;
     }
-    bool hasSimpleAlert() const
-    {
-        return hasSimpleAlert(m_btSpecObject);
-    }
 
-    static bool hasEmail(const AlertCategoryIDBitMaskStruct &btSpecObject)
+    BVP_GETTER(bool, hasEmail, AlertCategoryIDBitMaskStruct)
     {
         return (btSpecObject.categoryIDBitMask & ACI_FLAG_EMAIL) != 0;
     }
-    bool hasEmail() const
-    {
-        return hasEmail(m_btSpecObject);
-    }
 
-    static bool hasNews(const AlertCategoryIDBitMaskStruct &btSpecObject)
+    BVP_GETTER(bool, hasNews, AlertCategoryIDBitMaskStruct)
     {
         return (btSpecObject.categoryIDBitMask & ACI_FLAG_NEWS) != 0;
     }
-    bool hasNews() const
-    {
-        return hasNews(m_btSpecObject);
-    }
 
-    static bool hasCall(const AlertCategoryIDBitMaskStruct &btSpecObject)
+    BVP_GETTER(bool, hasCall, AlertCategoryIDBitMaskStruct)
     {
         return (btSpecObject.categoryIDBitMask & ACI_FLAG_CALL) != 0;
     }
-    bool hasCall() const
-    {
-        return hasCall(m_btSpecObject);
-    }
 
-    static bool hasMissedCall(const AlertCategoryIDBitMaskStruct &btSpecObject)
+    BVP_GETTER(bool, hasMissedCall, AlertCategoryIDBitMaskStruct)
     {
         return (btSpecObject.categoryIDBitMask & ACI_FLAG_MISSED_CALL) != 0;
     }
-    bool hasMissedCall() const
-    {
-        return hasMissedCall(m_btSpecObject);
-    }
 
-    static bool hasSMSMMS(const AlertCategoryIDBitMaskStruct &btSpecObject)
+    BVP_GETTER(bool, hasSMSMMS, AlertCategoryIDBitMaskStruct)
     {
         return (btSpecObject.categoryIDBitMask & ACI_FLAG_SMS_MMS) != 0;
     }
-    bool hasSMSMMS() const
-    {
-        return hasSMSMMS(m_btSpecObject);
-    }
 
-    static bool hasVoiceMail(const AlertCategoryIDBitMaskStruct &btSpecObject)
+    BVP_GETTER(bool, hasVoiceMail, AlertCategoryIDBitMaskStruct)
     {
         return (btSpecObject.categoryIDBitMask & ACI_FLAG_VOICE_MAIL) != 0;
     }
-    bool hasVoiceMail() const
-    {
-        return hasVoiceMail(m_btSpecObject);
-    }
 
-    static bool hasSchedule(const AlertCategoryIDBitMaskStruct &btSpecObject)
+    BVP_GETTER(bool, hasSchedule, AlertCategoryIDBitMaskStruct)
     {
         return (btSpecObject.categoryIDBitMask & ACI_FLAG_SCHEDULE) != 0;
     }
-    bool hasSchedule() const
-    {
-        return hasSchedule(m_btSpecObject);
-    }
 
-    static bool hasHighPrioritizedAlert(const AlertCategoryIDBitMaskStruct &btSpecObject)
+    BVP_GETTER(bool, hasHighPrioritizedAlert, AlertCategoryIDBitMaskStruct)
     {
         return (btSpecObject.categoryIDBitMask & ACI_FLAG_HIGH_PRIORITIZED_ALERT) != 0;
     }
-    bool hasHighPrioritizedAlert() const
-    {
-        return hasHighPrioritizedAlert(m_btSpecObject);
-    }
 
-    static bool hasInstantMessage(const AlertCategoryIDBitMaskStruct &btSpecObject)
+    BVP_GETTER(bool, hasInstantMessage, AlertCategoryIDBitMaskStruct)
     {
         return (btSpecObject.categoryIDBitMask & ACI_FLAG_INSTANT_MESSAGE) != 0;
-    }
-    bool hasInstantMessage() const
-    {
-        return hasInstantMessage(m_btSpecObject);
     }
 
 private:
@@ -136,17 +96,13 @@ private:
         return size == 2;
     }
 
-    static bool parse(Parser &parser, AlertCategoryIDBitMaskStruct &btSpecObject)
+    BVP_PARSE(AlertCategoryIDBitMaskStruct)
     {
         bool result{true};
 
         btSpecObject.categoryIDBitMask = parser.parseUInt16();
 
         return result;
-    }
-    virtual bool parse(Parser &parser) override
-    {
-        return parse(parser, m_btSpecObject);
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/alertnotificationcontrolpoint.h
+++ b/include/blevalueparser/alertnotificationcontrolpoint.h
@@ -68,22 +68,14 @@ struct AlertNotificationControlPointStruct
 class AlertNotificationControlPoint final : public BaseValueSpec<AlertNotificationControlPointStruct>
 {
 public:
-    static AlertNotificationControlPointCommandIDEnum commandID(const AlertNotificationControlPointStruct &btSpecObject)
+    BVP_GETTER(AlertNotificationControlPointCommandIDEnum, commandID, AlertNotificationControlPointStruct)
     {
-            return btSpecObject.commandID;
-    }
-    AlertNotificationControlPointCommandIDEnum commandID() const
-    {
-            return commandID(m_btSpecObject);
+        return btSpecObject.commandID;
     }
 
-    static AlertCategoryIDEnum categoryID(const AlertNotificationControlPointStruct &btSpecObject)
+    BVP_GETTER(AlertCategoryIDEnum, categoryID, AlertNotificationControlPointStruct)
     {
-            return btSpecObject.categoryID.categoryID;
-    }
-    AlertCategoryIDEnum categoryID() const
-    {
-            return categoryID(m_btSpecObject);
+        return btSpecObject.categoryID.categoryID;
     }
 
 private:
@@ -94,7 +86,7 @@ private:
         return size == 2;
     }
 
-    static bool parse(Parser &parser, AlertNotificationControlPointStruct &btSpecObject)
+    BVP_PARSE(AlertNotificationControlPointStruct)
     {
         bool result{true};
 
@@ -102,10 +94,6 @@ private:
         result &= AlertCategoryID::parse(parser, btSpecObject.categoryID);
 
         return result;
-    }
-    virtual bool parse(Parser &parser) override
-    {
-        return parse(parser, m_btSpecObject);
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/batterycriticalstatus.h
+++ b/include/blevalueparser/batterycriticalstatus.h
@@ -30,14 +30,14 @@ struct BatteryCriticalStatusStruct
 class BatteryCriticalStatus final : public BaseValueSpec<BatteryCriticalStatusStruct>
 {
 public:
-    bool isCriticalPowerState() const
+    BVP_GETTER(bool, isCriticalPowerState, BatteryCriticalStatusStruct)
     {
-        return (m_btSpecObject.batteryCriticalStatus & BCS_FLAG_CRITICAL_POWER_STATE) != 0;
+        return (btSpecObject.batteryCriticalStatus & BCS_FLAG_CRITICAL_POWER_STATE) != 0;
     }
 
-    bool isImmediateServiceRequired() const
+    BVP_GETTER(bool, isImmediateServiceRequired, BatteryCriticalStatusStruct)
     {
-        return (m_btSpecObject.batteryCriticalStatus & BCS_FLAG_IMMEDIATE_SERVICE_REQUIRED) != 0;
+        return (btSpecObject.batteryCriticalStatus & BCS_FLAG_IMMEDIATE_SERVICE_REQUIRED) != 0;
     }
 
 private:
@@ -48,10 +48,13 @@ private:
         return size == 1;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(BatteryCriticalStatusStruct)
     {
-        m_btSpecObject.batteryCriticalStatus = parser.parseUInt8();
-        return true;
+        bool result{true};
+
+        btSpecObject.batteryCriticalStatus = parser.parseUInt8();
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/batteryenergystatus.h
+++ b/include/blevalueparser/batteryenergystatus.h
@@ -33,64 +33,64 @@ struct BatteryEnergyStatusStruct
 class BatteryEnergyStatus final : public BaseValueSpec<BatteryEnergyStatusStruct>
 {
 public:
-    bool isExternalSourcePowerPresent() const
+    BVP_GETTER(bool, isExternalSourcePowerPresent, BatteryEnergyStatusStruct)
     {
-        return (m_btSpecObject.flags & BES_FLAG_EXTERNAL_SOURCE_POWER_PRESENT) != 0;
+        return (btSpecObject.flags & BES_FLAG_EXTERNAL_SOURCE_POWER_PRESENT) != 0;
     }
 
-    bool isPresentVoltagePresent() const
+    BVP_GETTER(bool, isPresentVoltagePresent, BatteryEnergyStatusStruct)
     {
-        return (m_btSpecObject.flags & BES_FLAG_PRESENT_VOLTAGE_PRESENT) != 0;
+        return (btSpecObject.flags & BES_FLAG_PRESENT_VOLTAGE_PRESENT) != 0;
     }
 
-    bool isAvailableEnergyPresent() const
+    BVP_GETTER(bool, isAvailableEnergyPresent, BatteryEnergyStatusStruct)
     {
-        return (m_btSpecObject.flags & BES_FLAG_AVAILABLE_ENERGY_PRESENT) != 0;
+        return (btSpecObject.flags & BES_FLAG_AVAILABLE_ENERGY_PRESENT) != 0;
     }
 
-    bool isAvailableBatteryCapacityPresent() const
+    BVP_GETTER(bool, isAvailableBatteryCapacityPresent, BatteryEnergyStatusStruct)
     {
-        return (m_btSpecObject.flags & BES_FLAG_AVAILABLE_BATTERY_CAPACITY_PRESENT) != 0;
+        return (btSpecObject.flags & BES_FLAG_AVAILABLE_BATTERY_CAPACITY_PRESENT) != 0;
     }
 
-    bool isChargeRatePresent() const
+    BVP_GETTER(bool, isChargeRatePresent, BatteryEnergyStatusStruct)
     {
-        return (m_btSpecObject.flags & BES_FLAG_CHARGE_RATE_PRESENT) != 0;
+        return (btSpecObject.flags & BES_FLAG_CHARGE_RATE_PRESENT) != 0;
     }
 
-    bool isAvailableEnergyAtLastChargePresent() const
+    BVP_GETTER(bool, isAvailableEnergyAtLastChargePresent, BatteryEnergyStatusStruct)
     {
-        return (m_btSpecObject.flags & BES_FLAG_AVAILABLE_ENERGY_AT_LAST_CHARGE_PRESENT) != 0;
+        return (btSpecObject.flags & BES_FLAG_AVAILABLE_ENERGY_AT_LAST_CHARGE_PRESENT) != 0;
     }
 
-    MedFloat16 externalSourcePower() const
+    BVP_GETTER(MedFloat16, externalSourcePower, BatteryEnergyStatusStruct)
     {
-        return m_btSpecObject.externalSourcePower;
+        return btSpecObject.externalSourcePower;
     }
 
-    MedFloat16 presentVoltage() const
+    BVP_GETTER(MedFloat16, presentVoltage, BatteryEnergyStatusStruct)
     {
-        return m_btSpecObject.presentVoltage;
+        return btSpecObject.presentVoltage;
     }
 
-    MedFloat16 availableEnergy() const
+    BVP_GETTER(MedFloat16, availableEnergy, BatteryEnergyStatusStruct)
     {
-        return m_btSpecObject.availableEnergy;
+        return btSpecObject.availableEnergy;
     }
 
-    MedFloat16 availableBatteryCapacity() const
+    BVP_GETTER(MedFloat16, availableBatteryCapacity, BatteryEnergyStatusStruct)
     {
-        return m_btSpecObject.availableBatteryCapacity;
+        return btSpecObject.availableBatteryCapacity;
     }
 
-    MedFloat16 chargeRate() const
+    BVP_GETTER(MedFloat16, chargeRate, BatteryEnergyStatusStruct)
     {
-        return m_btSpecObject.chargeRate;
+        return btSpecObject.chargeRate;
     }
 
-    MedFloat16 availableEnergyAtLastCharge() const
+    BVP_GETTER(MedFloat16, availableEnergyAtLastCharge, BatteryEnergyStatusStruct)
     {
-        return m_btSpecObject.availableEnergyAtLastCharge;
+        return btSpecObject.availableEnergyAtLastCharge;
     }
 
 private:
@@ -101,36 +101,38 @@ private:
         return size > 0 && size < 14;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(BatteryEnergyStatusStruct)
     {
-        m_btSpecObject.flags = parser.parseUInt8();
+        bool result{true};
 
-        if (isExternalSourcePowerPresent())
+        btSpecObject.flags = parser.parseUInt8();
+
+        if (isExternalSourcePowerPresent(btSpecObject))
         {
-            m_btSpecObject.externalSourcePower = parser.parseMedFloat16();
+            btSpecObject.externalSourcePower = parser.parseMedFloat16();
         }
-        if (isPresentVoltagePresent())
+        if (isPresentVoltagePresent(btSpecObject))
         {
-            m_btSpecObject.presentVoltage = parser.parseMedFloat16();
+            btSpecObject.presentVoltage = parser.parseMedFloat16();
         }
-        if (isAvailableEnergyPresent())
+        if (isAvailableEnergyPresent(btSpecObject))
         {
-            m_btSpecObject.availableEnergy = parser.parseMedFloat16();
+            btSpecObject.availableEnergy = parser.parseMedFloat16();
         }
-        if (isAvailableBatteryCapacityPresent())
+        if (isAvailableBatteryCapacityPresent(btSpecObject))
         {
-            m_btSpecObject.availableBatteryCapacity = parser.parseMedFloat16();
+            btSpecObject.availableBatteryCapacity = parser.parseMedFloat16();
         }
-        if (isChargeRatePresent())
+        if (isChargeRatePresent(btSpecObject))
         {
-            m_btSpecObject.chargeRate = parser.parseMedFloat16();
+            btSpecObject.chargeRate = parser.parseMedFloat16();
         }
-        if (isAvailableEnergyAtLastChargePresent())
+        if (isAvailableEnergyAtLastChargePresent(btSpecObject))
         {
-            m_btSpecObject.availableEnergyAtLastCharge = parser.parseMedFloat16();
+            btSpecObject.availableEnergyAtLastCharge = parser.parseMedFloat16();
         }
 
-        return true;
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/batteryhealthinformation.h
+++ b/include/blevalueparser/batteryhealthinformation.h
@@ -30,49 +30,49 @@ struct BatteryHealthInformationStruct
 class BatteryHealthInformation final : public BaseValueSpec<BatteryHealthInformationStruct>
 {
 public:
-    bool isCycleCountDesignedLifetimePresent() const
+    BVP_GETTER(bool, isCycleCountDesignedLifetimePresent, BatteryHealthInformationStruct)
     {
-        return (m_btSpecObject.flags & BHI_FLAG_CYCLE_COUNT_DESIGNED_LIFETIME_PRESENT) != 0;
+        return (btSpecObject.flags & BHI_FLAG_CYCLE_COUNT_DESIGNED_LIFETIME_PRESENT) != 0;
     }
 
-    bool isMinAndMaxDesignedOperatingTemperaturePresent() const
+    BVP_GETTER(bool, isMinAndMaxDesignedOperatingTemperaturePresent, BatteryHealthInformationStruct)
     {
-        return (m_btSpecObject.flags & BHI_FLAG_MIN_AND_MAX_DESIGNED_OPERATING_TEMPERATURE_PRESENT) != 0;
+        return (btSpecObject.flags & BHI_FLAG_MIN_AND_MAX_DESIGNED_OPERATING_TEMPERATURE_PRESENT) != 0;
     }
 
-    uint16_t cycleCountDesignedLifetime() const
+    BVP_GETTER(uint16_t, cycleCountDesignedLifetime, BatteryHealthInformationStruct)
     {
-        return m_btSpecObject.cycleCountDesignedLifetime;
+        return btSpecObject.cycleCountDesignedLifetime;
     }
 
-    int8_t minDesignedOperatingTemperature() const
+    BVP_GETTER(int8_t, minDesignedOperatingTemperature, BatteryHealthInformationStruct)
     {
-        return m_btSpecObject.minDesignedOperatingTemperature;
+        return btSpecObject.minDesignedOperatingTemperature;
     }
 
-    int8_t maxDesignedOperatingTemperature() const
+    BVP_GETTER(int8_t, maxDesignedOperatingTemperature, BatteryHealthInformationStruct)
     {
-        return m_btSpecObject.maxDesignedOperatingTemperature;
+        return btSpecObject.maxDesignedOperatingTemperature;
     }
 
-    bool isMinDesignedOperatingTemperatureGreater() const
+    BVP_GETTER(bool, isMinDesignedOperatingTemperatureGreater, BatteryHealthInformationStruct)
     {
-        return s_greater == m_btSpecObject.minDesignedOperatingTemperature;
+        return s_greater == btSpecObject.minDesignedOperatingTemperature;
     }
 
-    bool isMinDesignedOperatingTemperatureLess() const
+    BVP_GETTER(bool, isMinDesignedOperatingTemperatureLess, BatteryHealthInformationStruct)
     {
-        return s_less == m_btSpecObject.minDesignedOperatingTemperature;
+        return s_less == btSpecObject.minDesignedOperatingTemperature;
     }
 
-    bool isMaxDesignedOperatingTemperatureGreater() const
+    BVP_GETTER(bool, isMaxDesignedOperatingTemperatureGreater, BatteryHealthInformationStruct)
     {
-        return s_greater == m_btSpecObject.maxDesignedOperatingTemperature;
+        return s_greater == btSpecObject.maxDesignedOperatingTemperature;
     }
 
-    bool isMaxDesignedOperatingTemperatureLess() const
+    BVP_GETTER(bool, isMaxDesignedOperatingTemperatureLess, BatteryHealthInformationStruct)
     {
-        return s_less == m_btSpecObject.maxDesignedOperatingTemperature;
+        return s_less == btSpecObject.maxDesignedOperatingTemperature;
     }
 
 private:
@@ -88,25 +88,27 @@ private:
         return size > 0 && size < 6;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(BatteryHealthInformationStruct)
     {
-        m_btSpecObject.flags = parser.parseUInt8();
+        bool result{true};
 
-        if (isCycleCountDesignedLifetimePresent())
+        btSpecObject.flags = parser.parseUInt8();
+
+        if (isCycleCountDesignedLifetimePresent(btSpecObject))
         {
-            m_btSpecObject.cycleCountDesignedLifetime = parser.parseUInt16();
+            btSpecObject.cycleCountDesignedLifetime = parser.parseUInt16();
         }
-        if (isMinAndMaxDesignedOperatingTemperaturePresent())
+        if (isMinAndMaxDesignedOperatingTemperaturePresent(btSpecObject))
         {
-            m_btSpecObject.minDesignedOperatingTemperature = parser.parseInt8();
-            m_btSpecObject.maxDesignedOperatingTemperature = parser.parseInt8();
-            if (m_btSpecObject.minDesignedOperatingTemperature > m_btSpecObject.maxDesignedOperatingTemperature)
+            btSpecObject.minDesignedOperatingTemperature = parser.parseInt8();
+            btSpecObject.maxDesignedOperatingTemperature = parser.parseInt8();
+            if (btSpecObject.minDesignedOperatingTemperature > btSpecObject.maxDesignedOperatingTemperature)
             {
                 return false;
             }
         }
 
-        return true;
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/batteryhealthstatus.h
+++ b/include/blevalueparser/batteryhealthstatus.h
@@ -31,54 +31,54 @@ struct BatteryHealthStatusStruct
 class BatteryHealthStatus final : public BaseValueSpec<BatteryHealthStatusStruct>
 {
 public:
-    bool isBatteryHealthSummaryPresent() const
+    BVP_GETTER(bool, isBatteryHealthSummaryPresent, BatteryHealthStatusStruct)
     {
-        return (m_btSpecObject.flags & BHS_FLAG_BATTERY_HEALTH_SUMMARY_PRESENT) != 0;
+        return (btSpecObject.flags & BHS_FLAG_BATTERY_HEALTH_SUMMARY_PRESENT) != 0;
     }
 
-    bool isCycleCountPresent() const
+    BVP_GETTER(bool, isCycleCountPresent, BatteryHealthStatusStruct)
     {
-        return (m_btSpecObject.flags & BHS_FLAG_CYCLE_COUNT_PRESENT) != 0;
+        return (btSpecObject.flags & BHS_FLAG_CYCLE_COUNT_PRESENT) != 0;
     }
 
-    bool isCurrentTemperaturePresent() const
+    BVP_GETTER(bool, isCurrentTemperaturePresent, BatteryHealthStatusStruct)
     {
-        return (m_btSpecObject.flags & BHS_FLAG_CURRENT_TEMPERATURE_PRESENT) != 0;
+        return (btSpecObject.flags & BHS_FLAG_CURRENT_TEMPERATURE_PRESENT) != 0;
     }
 
-    bool isDeepDischargeCountPresent() const
+    BVP_GETTER(bool, isDeepDischargeCountPresent, BatteryHealthStatusStruct)
     {
-        return (m_btSpecObject.flags & BHS_FLAG_DEEP_DISCHARGE_COUNT_PRESENT) != 0;
+        return (btSpecObject.flags & BHS_FLAG_DEEP_DISCHARGE_COUNT_PRESENT) != 0;
     }
 
-    uint8_t batteryHealthSummary() const
+    BVP_GETTER(uint8_t, batteryHealthSummary, BatteryHealthStatusStruct)
     {
-        return m_btSpecObject.batteryHealthSummary;
+        return btSpecObject.batteryHealthSummary;
     }
 
-    uint16_t cycleCount() const
+    BVP_GETTER(uint16_t, cycleCount, BatteryHealthStatusStruct)
     {
-        return m_btSpecObject.cycleCount;
+        return btSpecObject.cycleCount;
     }
 
-    int8_t currentTemperature() const
+    BVP_GETTER(int8_t, currentTemperature, BatteryHealthStatusStruct)
     {
-        return m_btSpecObject.currentTemperature;
+        return btSpecObject.currentTemperature;
     }
 
-    uint16_t deepDischargeCount() const
+    BVP_GETTER(uint16_t, deepDischargeCount, BatteryHealthStatusStruct)
     {
-        return m_btSpecObject.deepDischargeCount;
+        return btSpecObject.deepDischargeCount;
     }
 
-    bool isCurrentTemperatureGreater() const
+    BVP_GETTER(bool, isCurrentTemperatureGreater, BatteryHealthStatusStruct)
     {
-        return s_greater == m_btSpecObject.currentTemperature;
+        return s_greater == btSpecObject.currentTemperature;
     }
 
-    bool isCurrentTemperatureLess() const
+    BVP_GETTER(bool, isCurrentTemperatureLess, BatteryHealthStatusStruct)
     {
-        return s_less == m_btSpecObject.currentTemperature;
+        return s_less == btSpecObject.currentTemperature;
     }
 
 private:
@@ -94,32 +94,34 @@ private:
         return size > 0 && size < 8;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(BatteryHealthStatusStruct)
     {
-        m_btSpecObject.flags = parser.parseUInt8();
+        bool result{true};
 
-        if (isBatteryHealthSummaryPresent())
+        btSpecObject.flags = parser.parseUInt8();
+
+        if (isBatteryHealthSummaryPresent(btSpecObject))
         {
-            m_btSpecObject.batteryHealthSummary = parser.parseUInt8();
-            if (m_btSpecObject.batteryHealthSummary > 100)
+            btSpecObject.batteryHealthSummary = parser.parseUInt8();
+            if (btSpecObject.batteryHealthSummary > 100)
             {
                 return false;
             }
         }
-        if (isCycleCountPresent())
+        if (isCycleCountPresent(btSpecObject))
         {
-            m_btSpecObject.cycleCount = parser.parseUInt16();
+            btSpecObject.cycleCount = parser.parseUInt16();
         }
-        if (isCurrentTemperaturePresent())
+        if (isCurrentTemperaturePresent(btSpecObject))
         {
-            m_btSpecObject.currentTemperature = parser.parseInt8();
+            btSpecObject.currentTemperature = parser.parseInt8();
         }
-        if (isDeepDischargeCountPresent())
+        if (isDeepDischargeCountPresent(btSpecObject))
         {
-            m_btSpecObject.deepDischargeCount = parser.parseUInt16();
+            btSpecObject.deepDischargeCount = parser.parseUInt16();
         }
 
-        return true;
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/batteryinformation.h
+++ b/include/blevalueparser/batteryinformation.h
@@ -128,94 +128,94 @@ struct BatteryInformationStruct
 class BatteryInformation final : public BaseValueSpec<BatteryInformationStruct>
 {
 public:
-    bool isBatteryManufactureDatePresent() const
+    BVP_GETTER(bool, isBatteryManufactureDatePresent, BatteryInformationStruct)
     {
-        return (m_btSpecObject.flags & BAI_FLAG_BATTERY_MANUFACTURE_DATE_PRESENT) != 0;
+        return (btSpecObject.flags & BAI_FLAG_BATTERY_MANUFACTURE_DATE_PRESENT) != 0;
     }
 
-    bool isBatteryExpirationDatePresent() const
+    BVP_GETTER(bool, isBatteryExpirationDatePresent, BatteryInformationStruct)
     {
-        return (m_btSpecObject.flags & BAI_FLAG_BATTERY_EXPIRATION_DATE_PRESENT) != 0;
+        return (btSpecObject.flags & BAI_FLAG_BATTERY_EXPIRATION_DATE_PRESENT) != 0;
     }
 
-    bool isBatteryDesignedCapacityPresent() const
+    BVP_GETTER(bool, isBatteryDesignedCapacityPresent, BatteryInformationStruct)
     {
-        return (m_btSpecObject.flags & BAI_FLAG_BATTERY_DESIGNED_CAPACITY_PRESENT) != 0;
+        return (btSpecObject.flags & BAI_FLAG_BATTERY_DESIGNED_CAPACITY_PRESENT) != 0;
     }
 
-    bool isBatteryLowEnergyPresent() const
+    BVP_GETTER(bool, isBatteryLowEnergyPresent, BatteryInformationStruct)
     {
-        return (m_btSpecObject.flags & BAI_FLAG_BATTERY_LOW_ENERGY_PRESENT) != 0;
+        return (btSpecObject.flags & BAI_FLAG_BATTERY_LOW_ENERGY_PRESENT) != 0;
     }
 
-    bool isBatteryCriticalEnergyPresent() const
+    BVP_GETTER(bool, isBatteryCriticalEnergyPresent, BatteryInformationStruct)
     {
-        return (m_btSpecObject.flags & BAI_FLAG_BATTERY_CRITICAL_ENERGY_PRESENT) != 0;
+        return (btSpecObject.flags & BAI_FLAG_BATTERY_CRITICAL_ENERGY_PRESENT) != 0;
     }
 
-    bool isBatteryChemistryPresent() const
+    BVP_GETTER(bool, isBatteryChemistryPresent, BatteryInformationStruct)
     {
-        return (m_btSpecObject.flags & BAI_FLAG_BATTERY_CHEMISTRY_PRESENT) != 0;
+        return (btSpecObject.flags & BAI_FLAG_BATTERY_CHEMISTRY_PRESENT) != 0;
     }
 
-    bool isNominalVoltagePresent() const
+    BVP_GETTER(bool, isNominalVoltagePresent, BatteryInformationStruct)
     {
-        return (m_btSpecObject.flags & BAI_FLAG_NOMINAL_VOLTAGE_PRESENT) != 0;
+        return (btSpecObject.flags & BAI_FLAG_NOMINAL_VOLTAGE_PRESENT) != 0;
     }
 
-    bool isBatteryAggregationGroupPresent() const
+    BVP_GETTER(bool, isBatteryAggregationGroupPresent, BatteryInformationStruct)
     {
-        return (m_btSpecObject.flags & BAI_FLAG_BATTERY_AGGREGATION_GROUP_PRESENT) != 0;
+        return (btSpecObject.flags & BAI_FLAG_BATTERY_AGGREGATION_GROUP_PRESENT) != 0;
     }
 
-    bool isBatteryReplaceable() const
+    BVP_GETTER(bool, isBatteryReplaceable, BatteryInformationStruct)
     {
-        return (m_btSpecObject.batteryFeatures & BAI_FEATURE_BATTERY_REPLACEABLE) != 0;
+        return (btSpecObject.batteryFeatures & BAI_FEATURE_BATTERY_REPLACEABLE) != 0;
     }
 
-    bool isBatteryRechargeable() const
+    BVP_GETTER(bool, isBatteryRechargeable, BatteryInformationStruct)
     {
-        return (m_btSpecObject.batteryFeatures & BAI_FEATURE_BATTERY_RECHARGEABLE) != 0;
+        return (btSpecObject.batteryFeatures & BAI_FEATURE_BATTERY_RECHARGEABLE) != 0;
     }
 
-    DateUTCStruct batteryManufactureDate() const
+    BVP_GETTER(DateUTCStruct, batteryManufactureDate, BatteryInformationStruct)
     {
-        return m_btSpecObject.batteryManufactureDate;
+        return btSpecObject.batteryManufactureDate;
     }
 
-    DateUTCStruct batteryExpirationDate() const
+    BVP_GETTER(DateUTCStruct, batteryExpirationDate, BatteryInformationStruct)
     {
-        return m_btSpecObject.batteryExpirationDate;
+        return btSpecObject.batteryExpirationDate;
     }
 
-    MedFloat16 batteryDesignedCapacity() const
+    BVP_GETTER(MedFloat16, batteryDesignedCapacity, BatteryInformationStruct)
     {
-        return m_btSpecObject.batteryDesignedCapacity;
+        return btSpecObject.batteryDesignedCapacity;
     }
 
-    MedFloat16 batteryLowEnergy() const
+    BVP_GETTER(MedFloat16, batteryLowEnergy, BatteryInformationStruct)
     {
-        return m_btSpecObject.batteryLowEnergy;
+        return btSpecObject.batteryLowEnergy;
     }
 
-    MedFloat16 batteryCriticalEnergy() const
+    BVP_GETTER(MedFloat16, batteryCriticalEnergy, BatteryInformationStruct)
     {
-        return m_btSpecObject.batteryCriticalEnergy;
+        return btSpecObject.batteryCriticalEnergy;
     }
 
-    BatteryChemistryEnum batteryChemistry() const
+    BVP_GETTER(BatteryChemistryEnum, batteryChemistry, BatteryInformationStruct)
     {
-        return m_btSpecObject.batteryChemistry;
+        return btSpecObject.batteryChemistry;
     }
 
-    MedFloat16 nominalVoltage() const
+    BVP_GETTER(MedFloat16, nominalVoltage, BatteryInformationStruct)
     {
-        return m_btSpecObject.nominalVoltage;
+        return btSpecObject.nominalVoltage;
     }
 
-    uint8_t batteryAggregationGroup() const
+    BVP_GETTER(uint8_t, batteryAggregationGroup, BatteryInformationStruct)
     {
-        return m_btSpecObject.batteryAggregationGroup;
+        return btSpecObject.batteryAggregationGroup;
     }
 
 private:
@@ -226,45 +226,47 @@ private:
         return size > 2 && size < 20;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(BatteryInformationStruct)
     {
-        m_btSpecObject.flags = parser.parseUInt16();
-        m_btSpecObject.batteryFeatures = parser.parseUInt8();
+        bool result{true};
 
-        if (isBatteryManufactureDatePresent())
+        btSpecObject.flags = parser.parseUInt16();
+        btSpecObject.batteryFeatures = parser.parseUInt8();
+
+        if (isBatteryManufactureDatePresent(btSpecObject))
         {
-            m_btSpecObject.batteryManufactureDate = DateUTC(parser, configuration).getBtSpecObject();
+            result &= DateUTC::parse(parser, btSpecObject.batteryManufactureDate);
         }
-        if (isBatteryExpirationDatePresent())
+        if (isBatteryExpirationDatePresent(btSpecObject))
         {
-            m_btSpecObject.batteryExpirationDate = DateUTC(parser, configuration).getBtSpecObject();
+            result &= DateUTC::parse(parser, btSpecObject.batteryExpirationDate);
         }
-        if (isBatteryDesignedCapacityPresent())
+        if (isBatteryDesignedCapacityPresent(btSpecObject))
         {
-            m_btSpecObject.batteryDesignedCapacity = parser.parseMedFloat16();
+            btSpecObject.batteryDesignedCapacity = parser.parseMedFloat16();
         }
-        if (isBatteryLowEnergyPresent())
+        if (isBatteryLowEnergyPresent(btSpecObject))
         {
-            m_btSpecObject.batteryLowEnergy = parser.parseMedFloat16();
+            btSpecObject.batteryLowEnergy = parser.parseMedFloat16();
         }
-        if (isBatteryCriticalEnergyPresent())
+        if (isBatteryCriticalEnergyPresent(btSpecObject))
         {
-            m_btSpecObject.batteryCriticalEnergy = parser.parseMedFloat16();
+            btSpecObject.batteryCriticalEnergy = parser.parseMedFloat16();
         }
-        if (isBatteryChemistryPresent())
+        if (isBatteryChemistryPresent(btSpecObject))
         {
-            m_btSpecObject.batteryChemistry %= BatteryChemistryEnum(parser.parseUInt8());
+            btSpecObject.batteryChemistry %= BatteryChemistryEnum(parser.parseUInt8());
         }
-        if (isNominalVoltagePresent())
+        if (isNominalVoltagePresent(btSpecObject))
         {
-            m_btSpecObject.nominalVoltage = parser.parseMedFloat16();
+            btSpecObject.nominalVoltage = parser.parseMedFloat16();
         }
-        if (isBatteryAggregationGroupPresent())
+        if (isBatteryAggregationGroupPresent(btSpecObject))
         {
-            m_btSpecObject.batteryAggregationGroup = parser.parseUInt8();
+            btSpecObject.batteryAggregationGroup = parser.parseUInt8();
         }
 
-        return true;
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override
@@ -275,11 +277,11 @@ private:
         std::ostringstream ossInfo;
         if (isBatteryManufactureDatePresent())
         {
-            ossInfo << ", BatteryManufactureDate: " << DateUTC(m_btSpecObject.batteryManufactureDate, configuration);
+            ossInfo << ", BatteryManufactureDate: " << DateUTC(m_btSpecObject.batteryManufactureDate, configuration());
         }
         if (isBatteryExpirationDatePresent())
         {
-            ossInfo << ", BatteryExpirationDate: " << DateUTC(m_btSpecObject.batteryExpirationDate, configuration);
+            ossInfo << ", BatteryExpirationDate: " << DateUTC(m_btSpecObject.batteryExpirationDate, configuration());
         }
         if (isBatteryDesignedCapacityPresent())
         {

--- a/include/blevalueparser/batterylevel.h
+++ b/include/blevalueparser/batterylevel.h
@@ -21,9 +21,9 @@ class BatteryLevel final : public BaseValueSpec<BatteryLevelStruct>
 public:
     friend class BatteryLevelStatus;
 
-    uint8_t level() const
+    BVP_GETTER(uint8_t, level, BatteryLevelStruct)
     {
-        return m_btSpecObject.batteryLevel;
+        return btSpecObject.batteryLevel;
     }
 
 private:
@@ -34,15 +34,17 @@ private:
         return size == 1;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(BatteryLevelStruct)
     {
-        m_btSpecObject.batteryLevel = parser.parseUInt8();
-        if (m_btSpecObject.batteryLevel > 100)
+        bool result{true};
+
+        btSpecObject.batteryLevel = parser.parseUInt8();
+        if (btSpecObject.batteryLevel > 100)
         {
             return false;
         }
 
-        return true;
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/batterylevelstatus.h
+++ b/include/blevalueparser/batterylevelstatus.h
@@ -180,123 +180,123 @@ struct BatteryLevelStatusStruct
 class BatteryLevelStatus final : public BaseValueSpec<BatteryLevelStatusStruct>
 {
 public:
-    bool isIdentifierPresent() const
+    BVP_GETTER(bool, isIdentifierPresent, BatteryLevelStatusStruct)
     {
-        return (m_btSpecObject.flags & BAS_FLAG_IDENTIFIER_PRESENT) != 0;
+        return (btSpecObject.flags & BAS_FLAG_IDENTIFIER_PRESENT) != 0;
     }
 
-    bool isBatteryLevelPresent() const
+    BVP_GETTER(bool, isBatteryLevelPresent, BatteryLevelStatusStruct)
     {
-        return (m_btSpecObject.flags & BAS_FLAG_BATTERY_LEVEL_PRESENT) != 0;
+        return (btSpecObject.flags & BAS_FLAG_BATTERY_LEVEL_PRESENT) != 0;
     }
 
-    bool isAdditionalStatusPresent() const
+    BVP_GETTER(bool, isAdditionalStatusPresent, BatteryLevelStatusStruct)
     {
-        return (m_btSpecObject.flags & BAS_FLAG_ADDITIONAL_STATUS_PRESENT) != 0;
+        return (btSpecObject.flags & BAS_FLAG_ADDITIONAL_STATUS_PRESENT) != 0;
     }
 
-    bool isBatteryPresent() const
+    BVP_GETTER(bool, isBatteryPresent, BatteryLevelStatusStruct)
     {
-        return (m_btSpecObject.powerState & BAS_PS_BATTERY_PRESENT) != 0;
+        return (btSpecObject.powerState & BAS_PS_BATTERY_PRESENT) != 0;
     }
 
-    ExternalPowerSourceConnectedEnum wiredExternalPowerSourceConnected() const
+    BVP_GETTER(ExternalPowerSourceConnectedEnum, wiredExternalPowerSourceConnected, BatteryLevelStatusStruct)
     {
         uint16_t value =
-            (m_btSpecObject.powerState & BAS_PS_WIRED_EXTERNAL_POWER_SOURCE_CONNECTED0) +
-            (m_btSpecObject.powerState & BAS_PS_WIRED_EXTERNAL_POWER_SOURCE_CONNECTED1);
+            (btSpecObject.powerState & BAS_PS_WIRED_EXTERNAL_POWER_SOURCE_CONNECTED0) +
+            (btSpecObject.powerState & BAS_PS_WIRED_EXTERNAL_POWER_SOURCE_CONNECTED1);
         value = value >> BAS_PS_WIRED_EXTERNAL_POWER_SOURCE_CONNECTED_SHIFT;
 
         return ExternalPowerSourceConnectedEnum(value);
     }
 
-    ExternalPowerSourceConnectedEnum wirelessExternalPowerSourceConnected() const
+    BVP_GETTER(ExternalPowerSourceConnectedEnum, wirelessExternalPowerSourceConnected, BatteryLevelStatusStruct)
     {
         uint16_t value =
-            (m_btSpecObject.powerState & BAS_PS_WIRELESS_EXTERNAL_POWER_SOURCE_CONNECTED0) +
-            (m_btSpecObject.powerState & BAS_PS_WIRELESS_EXTERNAL_POWER_SOURCE_CONNECTED1);
+            (btSpecObject.powerState & BAS_PS_WIRELESS_EXTERNAL_POWER_SOURCE_CONNECTED0) +
+            (btSpecObject.powerState & BAS_PS_WIRELESS_EXTERNAL_POWER_SOURCE_CONNECTED1);
         value = value >> BAS_PS_WIRELESS_EXTERNAL_POWER_SOURCE_CONNECTED_SHIFT;
 
         return ExternalPowerSourceConnectedEnum(value);
     }
 
-    BatteryChargeStateEnum batteryChargeState() const
+    BVP_GETTER(BatteryChargeStateEnum, batteryChargeState, BatteryLevelStatusStruct)
     {
         uint16_t value =
-            (m_btSpecObject.powerState & BAS_PS_BATTERY_CHARGE_STATE0) +
-            (m_btSpecObject.powerState & BAS_PS_BATTERY_CHARGE_STATE1);
+            (btSpecObject.powerState & BAS_PS_BATTERY_CHARGE_STATE0) +
+            (btSpecObject.powerState & BAS_PS_BATTERY_CHARGE_STATE1);
         value = value >> BAS_PS_BATTERY_CHARGE_STATE_SHIFT;
 
         return BatteryChargeStateEnum(value);
     }
 
-    BatteryChargeLevelEnum batteryChargeLevel() const
+    BVP_GETTER(BatteryChargeLevelEnum, batteryChargeLevel, BatteryLevelStatusStruct)
     {
         uint16_t value =
-            (m_btSpecObject.powerState & BAS_PS_BATTERY_CHARGE_LEVEL0) +
-            (m_btSpecObject.powerState & BAS_PS_BATTERY_CHARGE_LEVEL1);
+            (btSpecObject.powerState & BAS_PS_BATTERY_CHARGE_LEVEL0) +
+            (btSpecObject.powerState & BAS_PS_BATTERY_CHARGE_LEVEL1);
         value = value >> BAS_PS_BATTERY_CHARGE_LEVEL_SHIFT;
 
         return BatteryChargeLevelEnum(value);
     }
 
-    ChargingTypeEnum chargingType() const
+    BVP_GETTER(ChargingTypeEnum, chargingType, BatteryLevelStatusStruct)
     {
         uint16_t value =
-            (m_btSpecObject.powerState & BAS_PS_CHARGING_TYPE0) +
-            (m_btSpecObject.powerState & BAS_PS_CHARGING_TYPE1) +
-            (m_btSpecObject.powerState & BAS_PS_CHARGING_TYPE2);
+            (btSpecObject.powerState & BAS_PS_CHARGING_TYPE0) +
+            (btSpecObject.powerState & BAS_PS_CHARGING_TYPE1) +
+            (btSpecObject.powerState & BAS_PS_CHARGING_TYPE2);
         value = value >> BAS_PS_CHARGING_TYPE_SHIFT;
 
         return ChargingTypeEnum(value);
     }
 
-    bool isChargingFaultReasonBattery() const
+    BVP_GETTER(bool, isChargingFaultReasonBattery, BatteryLevelStatusStruct)
     {
-        return (m_btSpecObject.powerState & BAS_PS_CHARGING_FAULT_REASON_BATTERY) != 0;
+        return (btSpecObject.powerState & BAS_PS_CHARGING_FAULT_REASON_BATTERY) != 0;
     }
 
-    bool isChargingFaultReasonExternalPowerSource() const
+    BVP_GETTER(bool, isChargingFaultReasonExternalPowerSource, BatteryLevelStatusStruct)
     {
-        return (m_btSpecObject.powerState & BAS_PS_CHARGING_FAULT_REASON_EXTERNAL_POWER_SOURCE) != 0;
+        return (btSpecObject.powerState & BAS_PS_CHARGING_FAULT_REASON_EXTERNAL_POWER_SOURCE) != 0;
     }
 
-    bool isChargingFaultReasonOther() const
+    BVP_GETTER(bool, isChargingFaultReasonOther, BatteryLevelStatusStruct)
     {
-        return (m_btSpecObject.powerState & BAS_PS_CHARGING_FAULT_REASON_OTHER) != 0;
+        return (btSpecObject.powerState & BAS_PS_CHARGING_FAULT_REASON_OTHER) != 0;
     }
 
-    bool hasChargingFault() const
+    BVP_GETTER(bool, hasChargingFault, BatteryLevelStatusStruct)
     {
         return
-            isChargingFaultReasonBattery() ||
-            isChargingFaultReasonExternalPowerSource() ||
-            isChargingFaultReasonOther();
+            isChargingFaultReasonBattery(btSpecObject) ||
+            isChargingFaultReasonExternalPowerSource(btSpecObject) ||
+            isChargingFaultReasonOther(btSpecObject);
     }
 
-    uint16_t identifier() const
+    BVP_GETTER(uint16_t, identifier, BatteryLevelStatusStruct)
     {
-        return m_btSpecObject.identifier;
+        return btSpecObject.identifier;
     }
 
-    uint8_t batteryLevel() const
+    BVP_GETTER(uint8_t, batteryLevel, BatteryLevelStatusStruct)
     {
-        return m_btSpecObject.batteryLevel.batteryLevel;
+        return btSpecObject.batteryLevel.batteryLevel;
     }
 
-    ServiceRequiredEnum serviceRequired() const
+    BVP_GETTER(ServiceRequiredEnum, serviceRequired, BatteryLevelStatusStruct)
     {
         uint8_t value =
-            (m_btSpecObject.additionalStatus & BAS_AS_SERVICE_REQUIRED0) +
-            (m_btSpecObject.additionalStatus & BAS_AS_SERVICE_REQUIRED1);
+            (btSpecObject.additionalStatus & BAS_AS_SERVICE_REQUIRED0) +
+            (btSpecObject.additionalStatus & BAS_AS_SERVICE_REQUIRED1);
         value = value >> BAS_AS_SERVICE_REQUIRED_SHIFT;
 
         return ServiceRequiredEnum(value);
     }
 
-    bool hasBatteryFault() const
+    BVP_GETTER(bool, hasBatteryFault, BatteryLevelStatusStruct)
     {
-        return (m_btSpecObject.additionalStatus & BAS_AS_BATTERY_FAULT) != 0;
+        return (btSpecObject.additionalStatus & BAS_AS_BATTERY_FAULT) != 0;
     }
 
 private:
@@ -307,27 +307,29 @@ private:
         return size > 2 && size < 8;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(BatteryLevelStatusStruct)
     {
-        m_btSpecObject.flags = parser.parseUInt8();
-        m_btSpecObject.powerState = parser.parseUInt16();
+        bool result{true};
 
-        if (isIdentifierPresent())
+        btSpecObject.flags = parser.parseUInt8();
+        btSpecObject.powerState = parser.parseUInt16();
+
+        if (isIdentifierPresent(btSpecObject))
         {
-            m_btSpecObject.identifier = parser.parseUInt16();
+            btSpecObject.identifier = parser.parseUInt16();
         }
 
-        if (isBatteryLevelPresent())
+        if (isBatteryLevelPresent(btSpecObject))
         {
-            m_btSpecObject.batteryLevel = BatteryLevel(parser, configuration).getBtSpecObject();
+            result &= BatteryLevel::parse(parser, btSpecObject.batteryLevel);
         }
 
-        if (isAdditionalStatusPresent())
+        if (isAdditionalStatusPresent(btSpecObject))
         {
-            m_btSpecObject.additionalStatus = parser.parseUInt8();
+            btSpecObject.additionalStatus = parser.parseUInt8();
         }
 
-        return true;
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override
@@ -365,7 +367,7 @@ private:
 
         if (isBatteryLevelPresent())
         {
-            oss << ", BatteryLevel: " << BatteryLevel(m_btSpecObject.batteryLevel, configuration);
+            oss << ", BatteryLevel: " << BatteryLevel(m_btSpecObject.batteryLevel, configuration());
         }
 
         if (isAdditionalStatusPresent())

--- a/include/blevalueparser/batterytimestatus.h
+++ b/include/blevalueparser/batterytimestatus.h
@@ -30,59 +30,59 @@ struct BatteryTimeStatusStruct
 class BatteryTimeStatus final : public BaseValueSpec<BatteryTimeStatusStruct>
 {
 public:
-    bool isTimeUntilDischargedOnStandbyPresent() const
+    BVP_GETTER(bool, isTimeUntilDischargedOnStandbyPresent, BatteryTimeStatusStruct)
     {
-        return (m_btSpecObject.flags & BTS_FLAG_TIME_UNTIL_DISCHARGED_ON_STANDBY_PRESENT) != 0;
+        return (btSpecObject.flags & BTS_FLAG_TIME_UNTIL_DISCHARGED_ON_STANDBY_PRESENT) != 0;
     }
 
-    bool isTimeUntilRechargedPresent() const
+    BVP_GETTER(bool, isTimeUntilRechargedPresent, BatteryTimeStatusStruct)
     {
-        return (m_btSpecObject.flags & BTS_FLAG_TIME_UNTIL_RECHARGED_PRESENT) != 0;
+        return (btSpecObject.flags & BTS_FLAG_TIME_UNTIL_RECHARGED_PRESENT) != 0;
     }
 
-    uint32_t timeUntilDischarged() const
+    BVP_GETTER(uint32_t, timeUntilDischarged, BatteryTimeStatusStruct)
     {
-        return m_btSpecObject.timeUntilDischarged;
+        return btSpecObject.timeUntilDischarged;
     }
 
-    uint32_t timeUntilDischargedOnStandby() const
+    BVP_GETTER(uint32_t, timeUntilDischargedOnStandby, BatteryTimeStatusStruct)
     {
-        return m_btSpecObject.timeUntilDischargedOnStandby;
+        return btSpecObject.timeUntilDischargedOnStandby;
     }
 
-    uint32_t timeUntilRecharged() const
+    BVP_GETTER(uint32_t, timeUntilRecharged, BatteryTimeStatusStruct)
     {
-        return m_btSpecObject.timeUntilRecharged;
+        return btSpecObject.timeUntilRecharged;
     }
 
-    bool isTimeUntilDischargedUnknown() const
+    BVP_GETTER(bool, isTimeUntilDischargedUnknown, BatteryTimeStatusStruct)
     {
-        return s_unknown == m_btSpecObject.timeUntilDischarged;
+        return s_unknown == btSpecObject.timeUntilDischarged;
     }
 
-    bool isTimeUntilDischargedOnStandbyUnknown() const
+    BVP_GETTER(bool, isTimeUntilDischargedOnStandbyUnknown, BatteryTimeStatusStruct)
     {
-        return s_unknown == m_btSpecObject.timeUntilDischargedOnStandby;
+        return s_unknown == btSpecObject.timeUntilDischargedOnStandby;
     }
 
-    bool isTimeUntilRechargedUnknown() const
+    BVP_GETTER(bool, isTimeUntilRechargedUnknown, BatteryTimeStatusStruct)
     {
-        return s_unknown == m_btSpecObject.timeUntilRecharged;
+        return s_unknown == btSpecObject.timeUntilRecharged;
     }
 
-    bool isTimeUntilDischargedGreater() const
+    BVP_GETTER(bool, isTimeUntilDischargedGreater, BatteryTimeStatusStruct)
     {
-        return s_greater == m_btSpecObject.timeUntilDischarged;
+        return s_greater == btSpecObject.timeUntilDischarged;
     }
 
-    bool isTimeUntilDischargedOnStandbyGreater() const
+    BVP_GETTER(bool, isTimeUntilDischargedOnStandbyGreater, BatteryTimeStatusStruct)
     {
-        return s_greater == m_btSpecObject.timeUntilDischargedOnStandby;
+        return s_greater == btSpecObject.timeUntilDischargedOnStandby;
     }
 
-    bool isTimeUntilRechargedGreater() const
+    BVP_GETTER(bool, isTimeUntilRechargedGreater, BatteryTimeStatusStruct)
     {
-        return s_greater == m_btSpecObject.timeUntilRecharged;
+        return s_greater == btSpecObject.timeUntilRecharged;
     }
 
 private:
@@ -97,21 +97,23 @@ private:
         return size > 3 && size < 11;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(BatteryTimeStatusStruct)
     {
-        m_btSpecObject.flags = parser.parseUInt8();
-        m_btSpecObject.timeUntilDischarged = parser.parseUInt24();
+        bool result{true};
 
-        if (isTimeUntilDischargedOnStandbyPresent())
+        btSpecObject.flags = parser.parseUInt8();
+        btSpecObject.timeUntilDischarged = parser.parseUInt24();
+
+        if (isTimeUntilDischargedOnStandbyPresent(btSpecObject))
         {
-            m_btSpecObject.timeUntilDischargedOnStandby = parser.parseUInt24();
+            btSpecObject.timeUntilDischargedOnStandby = parser.parseUInt24();
         }
-        if (isTimeUntilRechargedPresent())
+        if (isTimeUntilRechargedPresent(btSpecObject))
         {
-            m_btSpecObject.timeUntilRecharged = parser.parseUInt24();
+            btSpecObject.timeUntilRecharged = parser.parseUInt24();
         }
 
-        return true;
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/bodycompositionfeature.h
+++ b/include/blevalueparser/bodycompositionfeature.h
@@ -57,68 +57,68 @@ struct BodyCompositionFeatureStruct
 class BodyCompositionFeature final : public BaseValueSpec<BodyCompositionFeatureStruct>
 {
 public:
-    bool isTimeStampSupported() const
+    BVP_GETTER(bool, isTimeStampSupported, BodyCompositionFeatureStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCF_TIME_STAMP_SUPPORTED) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCF_TIME_STAMP_SUPPORTED) != 0;
     }
 
-    bool isMultipleUsersSupported() const
+    BVP_GETTER(bool, isMultipleUsersSupported, BodyCompositionFeatureStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCF_MULTIPLE_USERS_SUPPORTED) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCF_MULTIPLE_USERS_SUPPORTED) != 0;
     }
 
-    bool isBasalMetabolismSupported() const
+    BVP_GETTER(bool, isBasalMetabolismSupported, BodyCompositionFeatureStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCF_BASAL_METABOLISM_SUPPORTED) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCF_BASAL_METABOLISM_SUPPORTED) != 0;
     }
 
-    bool isMusclePercentageSupported() const
+    BVP_GETTER(bool, isMusclePercentageSupported, BodyCompositionFeatureStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCF_MUSCLE_PERCENTAGE_SUPPORTED) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCF_MUSCLE_PERCENTAGE_SUPPORTED) != 0;
     }
 
-    bool isMuscleMassSupported() const
+    BVP_GETTER(bool, isMuscleMassSupported, BodyCompositionFeatureStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCF_MUSCLE_MASS_SUPPORTED) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCF_MUSCLE_MASS_SUPPORTED) != 0;
     }
 
-    bool isFatFreeMassSupported() const
+    BVP_GETTER(bool, isFatFreeMassSupported, BodyCompositionFeatureStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCF_FAT_FREE_MASS_SUPPORTED) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCF_FAT_FREE_MASS_SUPPORTED) != 0;
     }
 
-    bool isSoftLeanMassSupported() const
+    BVP_GETTER(bool, isSoftLeanMassSupported, BodyCompositionFeatureStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCF_SOFT_LEAN_MASS_SUPPORTED) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCF_SOFT_LEAN_MASS_SUPPORTED) != 0;
     }
 
-    bool isBodyWaterMassSupported() const
+    BVP_GETTER(bool, isBodyWaterMassSupported, BodyCompositionFeatureStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCF_BODY_WATER_MASS_SUPPORTED) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCF_BODY_WATER_MASS_SUPPORTED) != 0;
     }
 
-    bool isImpedanceSupported() const
+    BVP_GETTER(bool, isImpedanceSupported, BodyCompositionFeatureStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCF_IMPEDANCE_SUPPORTED) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCF_IMPEDANCE_SUPPORTED) != 0;
     }
 
-    bool isWeightSupported() const
+    BVP_GETTER(bool, isWeightSupported, BodyCompositionFeatureStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCF_WEIGHT_SUPPORTED) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCF_WEIGHT_SUPPORTED) != 0;
     }
 
-    bool isHeightSupported() const
+    BVP_GETTER(bool, isHeightSupported, BodyCompositionFeatureStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCF_HEIGHT_SUPPORTED) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCF_HEIGHT_SUPPORTED) != 0;
     }
 
-    uint16_t weightResolution() const
+    BVP_GETTER_CONF(uint16_t, weightResolution, BodyCompositionFeatureStruct)
     {
         uint32_t resolution =
-            (m_btSpecObject.flags & BCS_FLAG_BCF_WEIGHT_RESOLUTION0) +
-            (m_btSpecObject.flags & BCS_FLAG_BCF_WEIGHT_RESOLUTION1) +
-            (m_btSpecObject.flags & BCS_FLAG_BCF_WEIGHT_RESOLUTION2) +
-            (m_btSpecObject.flags & BCS_FLAG_BCF_WEIGHT_RESOLUTION3);
+            (btSpecObject.flags & BCS_FLAG_BCF_WEIGHT_RESOLUTION0) +
+            (btSpecObject.flags & BCS_FLAG_BCF_WEIGHT_RESOLUTION1) +
+            (btSpecObject.flags & BCS_FLAG_BCF_WEIGHT_RESOLUTION2) +
+            (btSpecObject.flags & BCS_FLAG_BCF_WEIGHT_RESOLUTION3);
         resolution = resolution >> BCS_FLAG_BCF_WEIGHT_RESOLUTION_SHIFT;
 
         switch (configuration.measurementUnits)
@@ -156,12 +156,12 @@ public:
         return 0;
     }
 
-    uint16_t heightResolution() const
+    BVP_GETTER_CONF(uint16_t, heightResolution, BodyCompositionFeatureStruct)
     {
         uint32_t resolution =
-            (m_btSpecObject.flags & BCS_FLAG_BCF_HEIGHT_RESOLUTION0) +
-            (m_btSpecObject.flags & BCS_FLAG_BCF_HEIGHT_RESOLUTION1) +
-            (m_btSpecObject.flags & BCS_FLAG_BCF_HEIGHT_RESOLUTION2);
+            (btSpecObject.flags & BCS_FLAG_BCF_HEIGHT_RESOLUTION0) +
+            (btSpecObject.flags & BCS_FLAG_BCF_HEIGHT_RESOLUTION1) +
+            (btSpecObject.flags & BCS_FLAG_BCF_HEIGHT_RESOLUTION2);
         resolution = resolution >> BCS_FLAG_BCF_HEIGHT_RESOLUTION_SHIFT;
 
         switch (configuration.measurementUnits)
@@ -199,11 +199,13 @@ private:
         return size == 4;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(BodyCompositionFeatureStruct)
     {
-        m_btSpecObject.flags = parser.parseUInt32();
+        bool result{true};
 
-        return true;
+        btSpecObject.flags = parser.parseUInt32();
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override
@@ -225,13 +227,13 @@ private:
         if (isWeightSupported())
         {
             oss << ", WeightResolution: " << weightResolution() / 1000.0
-               << configuration.massUnits();
+                << configuration().massUnits();
         }
 
         if (isHeightSupported())
         {
             oss << ", HeightResolution: " << heightResolution() / 1000.0
-               << configuration.lenghtUnits();
+                << configuration().lenghtUnits();
         }
     }
 };

--- a/include/blevalueparser/bodycompositionmeasurement.h
+++ b/include/blevalueparser/bodycompositionmeasurement.h
@@ -15,91 +15,91 @@ class BodyCompositionMeasurement final : public BodyCompositionMeasurementBase
 private:
     BVP_CTORS(BodyCompositionMeasurementBase, BodyCompositionMeasurement, BodyCompositionMeasurementStruct)
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(BodyCompositionMeasurementStruct)
     {
-        // 3.2.1.1 Flags Field
-        m_btSpecObject.flags = parser.parseUInt16();
+        bool result{true};
 
-        configuration.measurementUnits = measurementUnits();
+        // 3.2.1.1 Flags Field
+        btSpecObject.flags = parser.parseUInt16();
 
         // 3.2.1.2 Body Fat Percentage Field
         // Unit is 1/10 of a percent
-        m_btSpecObject.bodyFatPercentage = parser.parseUInt16();
-        if (isMeasurementUnsuccessful())
+        btSpecObject.bodyFatPercentage = parser.parseUInt16();
+        if (isMeasurementUnsuccessful(btSpecObject))
         {
             return true;
         }
 
         // 3.2.1.3 Time Stamp Field
-        if (isTimeStampPresent())
+        if (isTimeStampPresent(btSpecObject))
         {
-            m_btSpecObject.timeStamp = DateTime(parser, configuration).getBtSpecObject();
+            result &= DateTime::parse(parser, btSpecObject.timeStamp);
         }
 
         // 3.2.1.4 User ID Field
-        if (isUserIDPresent())
+        if (isUserIDPresent(btSpecObject))
         {
-            m_btSpecObject.userID = UserIndex(parser, configuration).getBtSpecObject();
+            result &= UserIndex::parse(parser, btSpecObject.userID);
         }
 
         // 3.2.1.5 Basal Metabolism
         // Unit is kilojoules
-        if (isBasalMetabolismPresent())
+        if (isBasalMetabolismPresent(btSpecObject))
         {
-            m_btSpecObject.basalMetabolism = parser.parseUInt16();
+            btSpecObject.basalMetabolism = parser.parseUInt16();
         }
 
         // 3.2.1.6 Muscle Percentage
         // Unit is 1/10 of a percent
-        if (isMusclePercentagePresent())
+        if (isMusclePercentagePresent(btSpecObject))
         {
-            m_btSpecObject.musclePercentage = parser.parseUInt16();
+            btSpecObject.musclePercentage = parser.parseUInt16();
         }
 
         // 3.2.1.7 Muscle Mass
-        if (isMuscleMassPresent())
+        if (isMuscleMassPresent(btSpecObject))
         {
-            m_btSpecObject.muscleMass = parser.parseUInt16();
+            btSpecObject.muscleMass = parser.parseUInt16();
         }
 
         // 3.2.1.8 Fat Free Mass
-        if (isFatFreeMassPresent())
+        if (isFatFreeMassPresent(btSpecObject))
         {
-            m_btSpecObject.fatFreeMass = parser.parseUInt16();
+            btSpecObject.fatFreeMass = parser.parseUInt16();
         }
 
         // 3.2.1.9 Soft Lean Mass
-        if (isSoftLeanMassPresent())
+        if (isSoftLeanMassPresent(btSpecObject))
         {
-            m_btSpecObject.softLeanMass = parser.parseUInt16();
+            btSpecObject.softLeanMass = parser.parseUInt16();
         }
 
         // 3.2.1.10 Body Water Mass
-        if (isBodyWaterMassPresent())
+        if (isBodyWaterMassPresent(btSpecObject))
         {
-            m_btSpecObject.bodyWaterMass = parser.parseUInt16();
+            btSpecObject.bodyWaterMass = parser.parseUInt16();
         }
 
         // 3.2.1.11 Impedance
         // Unit is 1/10 of an Ohm
-        if (isImpedancePresent())
+        if (isImpedancePresent(btSpecObject))
         {
-            m_btSpecObject.impedance = parser.parseUInt16();
+            btSpecObject.impedance = parser.parseUInt16();
         }
 
         // 3.2.1.12 Weight
-        if (isWeightPresent())
+        if (isWeightPresent(btSpecObject))
         {
-            m_btSpecObject.weight = parser.parseUInt16();
+            btSpecObject.weight = parser.parseUInt16();
         }
 
         // 3.2.1.13 Height
-        if (isHeightPresent())
+        if (isHeightPresent(btSpecObject))
         {
-            m_btSpecObject.height = parser.parseUInt16();
+            btSpecObject.height = parser.parseUInt16();
         }
 
-        return true;
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override
@@ -114,12 +114,12 @@ private:
 
         if (isTimeStampPresent())
         {
-            oss << ", TimeStamp: " << DateTime(m_btSpecObject.timeStamp, configuration);
+            oss << ", TimeStamp: " << DateTime(m_btSpecObject.timeStamp, configuration());
         }
 
         if (isUserIDPresent())
         {
-            oss << ", UserID: " << UserIndex(m_btSpecObject.userID, configuration);
+            oss << ", UserID: " << UserIndex(m_btSpecObject.userID, configuration());
         }
 
         if (isBasalMetabolismPresent())
@@ -134,22 +134,22 @@ private:
 
         if (isMuscleMassPresent())
         {
-            oss << ", MuscleMass: " << muscleMass() << configuration.massUnits();
+            oss << ", MuscleMass: " << muscleMass() << configuration().massUnits();
         }
 
         if (isFatFreeMassPresent())
         {
-            oss << ", FatFreeMass: " << fatFreeMass() << configuration.massUnits();
+            oss << ", FatFreeMass: " << fatFreeMass() << configuration().massUnits();
         }
 
         if (isSoftLeanMassPresent())
         {
-            oss << ", SoftLeanMass: " << softLeanMass() << configuration.massUnits();
+            oss << ", SoftLeanMass: " << softLeanMass() << configuration().massUnits();
         }
 
         if (isBodyWaterMassPresent())
         {
-            oss << ", BodyWaterMass: " << bodyWaterMass() << configuration.massUnits();
+            oss << ", BodyWaterMass: " << bodyWaterMass() << configuration().massUnits();
         }
 
         if (isImpedancePresent())
@@ -159,12 +159,12 @@ private:
 
         if (isWeightPresent())
         {
-            oss << ", Weight: " << weight() << configuration.massUnits();
+            oss << ", Weight: " << weight() << configuration().massUnits();
         }
 
         if (isHeightPresent())
         {
-            oss << ", Height: " << height() << configuration.lenghtUnits();
+            oss << ", Height: " << height() << configuration().lenghtUnits();
         }
     }
 };

--- a/include/blevalueparser/bodycompositionmeasurementbase.h
+++ b/include/blevalueparser/bodycompositionmeasurementbase.h
@@ -54,159 +54,165 @@ class BodyCompositionMeasurementBase : public BaseValueSpec<BodyCompositionMeasu
 public:
     virtual ~BodyCompositionMeasurementBase() = default;
 
-    bool isMeasurementUnsuccessful() const
+    BVP_GETTER(bool, isMeasurementUnsuccessful, BodyCompositionMeasurementStruct)
     {
-        return 0xFFFF == m_btSpecObject.bodyFatPercentage;
+        return 0xFFFF == btSpecObject.bodyFatPercentage;
     }
 
-    MeasurementUnitsEnum measurementUnits() const
+    BVP_GETTER(MeasurementUnitsEnum, measurementUnits, BodyCompositionMeasurementStruct)
     {
-        return MeasurementUnitsEnum(m_btSpecObject.flags & BCS_FLAG_BCM_MEASUREMENT_UNITS);
+        return MeasurementUnitsEnum(btSpecObject.flags & BCS_FLAG_BCM_MEASUREMENT_UNITS);
     }
 
-    bool isTimeStampPresent() const
+    BVP_GETTER(bool, isTimeStampPresent, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_TIME_STAMP_PRESENT) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_TIME_STAMP_PRESENT) != 0;
     }
 
-    bool isUserIDPresent() const
+    BVP_GETTER(bool, isUserIDPresent, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_USER_ID_PRESENT) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_USER_ID_PRESENT) != 0;
     }
 
-    bool isBasalMetabolismPresent() const
+    BVP_GETTER(bool, isBasalMetabolismPresent, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_BASAL_METABOLISM_PRESENT) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_BASAL_METABOLISM_PRESENT) != 0;
     }
 
-    bool isMusclePercentagePresent() const
+    BVP_GETTER(bool, isMusclePercentagePresent, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_MUSCLE_PERCENTAGE_PRESENT) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_MUSCLE_PERCENTAGE_PRESENT) != 0;
     }
 
-    bool isMuscleMassPresent() const
+    BVP_GETTER(bool, isMuscleMassPresent, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_MUSCLE_MASS_PRESENT) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_MUSCLE_MASS_PRESENT) != 0;
     }
 
-    bool isFatFreeMassPresent() const
+    BVP_GETTER(bool, isFatFreeMassPresent, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_FAT_FREE_MASS_PRESENT) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_FAT_FREE_MASS_PRESENT) != 0;
     }
 
-    bool isSoftLeanMassPresent() const
+    BVP_GETTER(bool, isSoftLeanMassPresent, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_SOFT_LEAN_MASS_PRESENT) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_SOFT_LEAN_MASS_PRESENT) != 0;
     }
 
-    bool isBodyWaterMassPresent() const
+    BVP_GETTER(bool, isBodyWaterMassPresent, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_BODY_WATER_MASS_PRESENT) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_BODY_WATER_MASS_PRESENT) != 0;
     }
 
-    bool isImpedancePresent() const
+    BVP_GETTER(bool, isImpedancePresent, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_IMPEDANCE_PRESENT) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_IMPEDANCE_PRESENT) != 0;
     }
 
-    bool isWeightPresent() const
+    BVP_GETTER(bool, isWeightPresent, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_WEIGHT_PRESENT) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_WEIGHT_PRESENT) != 0;
     }
 
-    bool isHeightPresent() const
+    BVP_GETTER(bool, isHeightPresent, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_HEIGHT_PRESENT) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_HEIGHT_PRESENT) != 0;
     }
 
-    bool isMultiplePacketMeasurement() const
+    BVP_GETTER(bool, isMultiplePacketMeasurement, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_MULTIPLE_PACKET_MEASUREMENT) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_MULTIPLE_PACKET_MEASUREMENT) != 0;
     }
 
-    float bodyFatPercentage() const
+    BVP_GETTER(float, bodyFatPercentage, BodyCompositionMeasurementStruct)
     {
-        return m_btSpecObject.bodyFatPercentage / 10.0;
+        return btSpecObject.bodyFatPercentage / 10.0;
     }
 
-    uint16_t year() const
+    BVP_GETTER(uint16_t, year, BodyCompositionMeasurementStruct)
     {
-        return m_btSpecObject.timeStamp.year;
+        return btSpecObject.timeStamp.year;
     }
 
-    uint8_t month() const
+    BVP_GETTER(uint8_t, month, BodyCompositionMeasurementStruct)
     {
-        return m_btSpecObject.timeStamp.month;
+        return btSpecObject.timeStamp.month;
     }
 
-    uint8_t day() const
+    BVP_GETTER(uint8_t, day, BodyCompositionMeasurementStruct)
     {
-        return m_btSpecObject.timeStamp.day;
+        return btSpecObject.timeStamp.day;
     }
 
-    uint8_t hour() const
+    BVP_GETTER(uint8_t, hour, BodyCompositionMeasurementStruct)
     {
-        return m_btSpecObject.timeStamp.hour;
+        return btSpecObject.timeStamp.hour;
     }
 
-    uint8_t minute() const
+    BVP_GETTER(uint8_t, minute, BodyCompositionMeasurementStruct)
     {
-        return m_btSpecObject.timeStamp.minute;
+        return btSpecObject.timeStamp.minute;
     }
 
-    uint8_t seconds() const
+    BVP_GETTER(uint8_t, seconds, BodyCompositionMeasurementStruct)
     {
-        return m_btSpecObject.timeStamp.seconds;
+        return btSpecObject.timeStamp.seconds;
     }
 
-    uint8_t userID() const
+    BVP_GETTER(uint8_t, userID, BodyCompositionMeasurementStruct)
     {
-        return m_btSpecObject.userID.userIndex;
+        return btSpecObject.userID.userIndex;
     }
 
-    uint16_t basalMetabolism() const
+    BVP_GETTER(uint16_t, basalMetabolism, BodyCompositionMeasurementStruct)
     {
-        return m_btSpecObject.basalMetabolism;
+        return btSpecObject.basalMetabolism;
     }
 
-    float musclePercentage() const
+    BVP_GETTER(float, musclePercentage, BodyCompositionMeasurementStruct)
     {
-        return m_btSpecObject.musclePercentage / 10.0;
+        return btSpecObject.musclePercentage / 10.0;
     }
 
-    float muscleMass() const
+    BVP_GETTER_CONF(float, muscleMass, BodyCompositionMeasurementStruct)
     {
-        return configuration.massToUnits(m_btSpecObject.muscleMass);
+        return configuration.massToUnits(btSpecObject.muscleMass);
     }
 
-    float fatFreeMass() const
+    BVP_GETTER_CONF(float, fatFreeMass, BodyCompositionMeasurementStruct)
     {
-        return configuration.massToUnits(m_btSpecObject.fatFreeMass);
+        return configuration.massToUnits(btSpecObject.fatFreeMass);
     }
 
-    float softLeanMass() const
+    BVP_GETTER_CONF(float, softLeanMass, BodyCompositionMeasurementStruct)
     {
-        return configuration.massToUnits(m_btSpecObject.softLeanMass);
+        return configuration.massToUnits(btSpecObject.softLeanMass);
     }
 
-    float bodyWaterMass() const
+    BVP_GETTER_CONF(float, bodyWaterMass, BodyCompositionMeasurementStruct)
     {
-        return configuration.massToUnits(m_btSpecObject.bodyWaterMass);
+        return configuration.massToUnits(btSpecObject.bodyWaterMass);
     }
 
-    float impedance() const
+    BVP_GETTER(float, impedance, BodyCompositionMeasurementStruct)
     {
-        return m_btSpecObject.impedance / 10.0;
+        return btSpecObject.impedance / 10.0;
     }
 
-    float weight() const
+    BVP_GETTER_CONF(float, weight, BodyCompositionMeasurementStruct)
     {
-        return configuration.massToUnits(m_btSpecObject.weight);
+        return configuration.massToUnits(btSpecObject.weight);
     }
 
-    float height() const
+    BVP_GETTER_CONF(float, height, BodyCompositionMeasurementStruct)
     {
-        return configuration.lenghtToUnits(m_btSpecObject.height);
+        return configuration.lenghtToUnits(btSpecObject.height);
+    }
+
+    virtual Configuration configuration() const override
+    {
+        m_configuration.measurementUnits = measurementUnits();
+        return m_configuration;
     }
 
 protected:

--- a/include/blevalueparser/bodycompositionmeasurementmibfs.h
+++ b/include/blevalueparser/bodycompositionmeasurementmibfs.h
@@ -20,49 +20,49 @@ constexpr uint16_t BCS_FLAG_BCM_MIBFS_UNLOADED   = BCS_FLAG_BCM_RESERVED3;
 class BodyCompositionMeasurementMIBFS final : public BodyCompositionMeasurementBase
 {
 public:
-    bool isStabilized() const
+    BVP_GETTER(bool, isStabilized, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_MIBFS_STABILIZED) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_MIBFS_STABILIZED) != 0;
     }
 
-    bool isUnknown1() const
+    BVP_GETTER(bool, isUnknown, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_MIBFS_UNKNOWN1) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_MIBFS_UNKNOWN1) != 0;
     }
 
-    bool isUnloaded() const
+    BVP_GETTER(bool, isUnloaded, BodyCompositionMeasurementStruct)
     {
-        return (m_btSpecObject.flags & BCS_FLAG_BCM_MIBFS_UNLOADED) != 0;
+        return (btSpecObject.flags & BCS_FLAG_BCM_MIBFS_UNLOADED) != 0;
     }
 
 private:
     BVP_CTORS(BodyCompositionMeasurementBase, BodyCompositionMeasurementMIBFS, BodyCompositionMeasurementStruct)
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(BodyCompositionMeasurementStruct)
     {
-        // 3.2.1.1 Flags Field
-        m_btSpecObject.flags = parser.parseUInt16();
+        bool result{true};
 
-        configuration.measurementUnits = measurementUnits();
+        // 3.2.1.1 Flags Field
+        btSpecObject.flags = parser.parseUInt16();
 
         // 3.2.1.3 Time Stamp Field
-        if (isTimeStampPresent())
+        if (isTimeStampPresent(btSpecObject))
         {
-            m_btSpecObject.timeStamp = DateTime(parser, configuration).getBtSpecObject();
+            result &= DateTime::parse(parser, btSpecObject.timeStamp);
         }
 
         // 3.2.1.11 Impedance
         // Unit is 1/10 of an Ohm
         // Always present in data on Xiaomi scales
-        m_btSpecObject.impedance = parser.parseUInt16();
+        btSpecObject.impedance = parser.parseUInt16();
 
         // 3.2.1.12 Weight
-        if (isWeightPresent())
+        if (isWeightPresent(btSpecObject))
         {
-            m_btSpecObject.weight = parser.parseUInt16();
+            btSpecObject.weight = parser.parseUInt16();
         }
 
-        return true;
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override
@@ -71,7 +71,7 @@ private:
 
         if (isTimeStampPresent())
         {
-            oss << ", TimeStamp: " << DateTime(m_btSpecObject.timeStamp, configuration);
+            oss << ", TimeStamp: " << DateTime(m_btSpecObject.timeStamp, configuration());
         }
 
         if (isImpedancePresent())
@@ -81,7 +81,7 @@ private:
 
         if (isWeightPresent())
         {
-            oss << ", Weight: " << weight() << configuration.massUnits();
+            oss << ", Weight: " << weight() << configuration().massUnits();
         }
     }
 };

--- a/include/blevalueparser/bodysensorlocation.h
+++ b/include/blevalueparser/bodysensorlocation.h
@@ -69,9 +69,9 @@ struct BodySensorLocationStruct
 class BodySensorLocation final : public BaseValueSpec<BodySensorLocationStruct>
 {
 public:
-    BodySensorLocationEnum location() const
+    BVP_GETTER(BodySensorLocationEnum, location, BodySensorLocationStruct)
     {
-        return m_btSpecObject.bodySensorLocation;
+        return btSpecObject.bodySensorLocation;
     }
 
 private:
@@ -82,11 +82,13 @@ private:
         return size == 1;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(BodySensorLocationStruct)
     {
-        m_btSpecObject.bodySensorLocation %= BodySensorLocationEnum(parser.parseUInt8());
+        bool result{true};
 
-        return true;
+        btSpecObject.bodySensorLocation %= BodySensorLocationEnum(parser.parseUInt8());
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/currenttime.h
+++ b/include/blevalueparser/currenttime.h
@@ -37,69 +37,69 @@ struct CurrentTimeStruct
 class CurrentTime final : public BaseValueSpec<CurrentTimeStruct>
 {
 public:
-    uint16_t year() const
+    BVP_GETTER(uint16_t, year, CurrentTimeStruct)
     {
-        return m_btSpecObject.exactTime256.dayDateTime.dateTime.year;
+        return btSpecObject.exactTime256.dayDateTime.dateTime.year;
     }
 
-    uint8_t month() const
+    BVP_GETTER(uint8_t, month, CurrentTimeStruct)
     {
-        return m_btSpecObject.exactTime256.dayDateTime.dateTime.month;
+        return btSpecObject.exactTime256.dayDateTime.dateTime.month;
     }
 
-    uint8_t day() const
+    BVP_GETTER(uint8_t, day, CurrentTimeStruct)
     {
-        return m_btSpecObject.exactTime256.dayDateTime.dateTime.day;
+        return btSpecObject.exactTime256.dayDateTime.dateTime.day;
     }
 
-    uint8_t hour() const
+    BVP_GETTER(uint8_t, hour, CurrentTimeStruct)
     {
-        return m_btSpecObject.exactTime256.dayDateTime.dateTime.hour;
+        return btSpecObject.exactTime256.dayDateTime.dateTime.hour;
     }
 
-    uint8_t minute() const
+    BVP_GETTER(uint8_t, minute, CurrentTimeStruct)
     {
-        return m_btSpecObject.exactTime256.dayDateTime.dateTime.minute;
+        return btSpecObject.exactTime256.dayDateTime.dateTime.minute;
     }
 
-    uint8_t seconds() const
+    BVP_GETTER(uint8_t, seconds, CurrentTimeStruct)
     {
-        return m_btSpecObject.exactTime256.dayDateTime.dateTime.seconds;
+        return btSpecObject.exactTime256.dayDateTime.dateTime.seconds;
     }
 
-    DayOfWeekEnum dayOfWeek() const
+    BVP_GETTER(DayOfWeekEnum, dayOfWeek, CurrentTimeStruct)
     {
-        return m_btSpecObject.exactTime256.dayDateTime.dayOfWeek.dayOfWeek;
+        return btSpecObject.exactTime256.dayDateTime.dayOfWeek.dayOfWeek;
     }
 
-    uint8_t fractionsOfSeconds() const
+    BVP_GETTER(uint8_t, fractionsOfSeconds, CurrentTimeStruct)
     {
-        return m_btSpecObject.exactTime256.fractions256;
+        return btSpecObject.exactTime256.fractions256;
     }
 
-    uint16_t milliseconds() const
+    BVP_GETTER(uint16_t, milliseconds, CurrentTimeStruct)
     {
-        return m_btSpecObject.exactTime256.fractions256 * 1000 / 256;
+        return btSpecObject.exactTime256.fractions256 * 1000 / 256;
     }
 
-    bool isManuallyAdjusted() const
+    BVP_GETTER(bool, isManuallyAdjusted, CurrentTimeStruct)
     {
-        return (m_btSpecObject.adjustReason & CTS_FLAG_MANUAL) != 0;
+        return (btSpecObject.adjustReason & CTS_FLAG_MANUAL) != 0;
     }
 
-    bool isExternalReference() const
+    BVP_GETTER(bool, isExternalReference, CurrentTimeStruct)
     {
-        return (m_btSpecObject.adjustReason & CTS_FLAG_EXTERNAL) != 0;
+        return (btSpecObject.adjustReason & CTS_FLAG_EXTERNAL) != 0;
     }
 
-    bool isTZChanged() const
+    BVP_GETTER(bool, isTZChanged, CurrentTimeStruct)
     {
-        return (m_btSpecObject.adjustReason & CTS_FLAG_TZ_CHANGED) != 0;
+        return (btSpecObject.adjustReason & CTS_FLAG_TZ_CHANGED) != 0;
     }
 
-    bool isDSTChanged() const
+    BVP_GETTER(bool, isDSTChanged, CurrentTimeStruct)
     {
-        return (m_btSpecObject.adjustReason & CTS_FLAG_DST_CHANGED) != 0;
+        return (btSpecObject.adjustReason & CTS_FLAG_DST_CHANGED) != 0;
     }
 
 private:
@@ -110,22 +110,24 @@ private:
         return size == 10;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(CurrentTimeStruct)
     {
-        m_btSpecObject.exactTime256 = ExactTime256(parser, configuration).getBtSpecObject();
+        bool result{true};
+
+        result &= ExactTime256::parse(parser, btSpecObject.exactTime256);
 
         // 3.1.2.1 Manual Time Update
         // 3.1.2.2 External Reference Time Update
         // 3.1.2.3 Change of Time Zone
         // 3.1.2.4 Change of DST Offset
-        m_btSpecObject.adjustReason = parser.parseUInt8();
+        btSpecObject.adjustReason = parser.parseUInt8();
 
-        return true;
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override
     {
-        oss << ExactTime256(m_btSpecObject.exactTime256, configuration);
+        oss << ExactTime256(m_btSpecObject.exactTime256, configuration());
 
         std::ostringstream ossAdjustReasons;
         if (isManuallyAdjusted())

--- a/include/blevalueparser/datetime.h
+++ b/include/blevalueparser/datetime.h
@@ -30,34 +30,34 @@ public:
     friend class BodyCompositionMeasurement;
     friend class BodyCompositionMeasurementMIBFS;
 
-    uint16_t year() const
+    BVP_GETTER(uint16_t, year, DateTimeStruct)
     {
-        return m_btSpecObject.year;
+        return btSpecObject.year;
     }
 
-    uint8_t month() const
+    BVP_GETTER(uint8_t, month, DateTimeStruct)
     {
-        return m_btSpecObject.month;
+        return btSpecObject.month;
     }
 
-    uint8_t day() const
+    BVP_GETTER(uint8_t, day, DateTimeStruct)
     {
-        return m_btSpecObject.day;
+        return btSpecObject.day;
     }
 
-    uint8_t hour() const
+    BVP_GETTER(uint8_t, hour, DateTimeStruct)
     {
-        return m_btSpecObject.hour;
+        return btSpecObject.hour;
     }
 
-    uint8_t minute() const
+    BVP_GETTER(uint8_t, minute, DateTimeStruct)
     {
-        return m_btSpecObject.minute;
+        return btSpecObject.minute;
     }
 
-    uint8_t seconds() const
+    BVP_GETTER(uint8_t, seconds, DateTimeStruct)
     {
-        return m_btSpecObject.seconds;
+        return btSpecObject.seconds;
     }
 
 private:
@@ -68,16 +68,18 @@ private:
         return size == 7;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(DateTimeStruct)
     {
-        m_btSpecObject.year = parser.parseUInt16();
-        m_btSpecObject.month = parser.parseUInt8();
-        m_btSpecObject.day = parser.parseUInt8();
-        m_btSpecObject.hour = parser.parseUInt8();
-        m_btSpecObject.minute = parser.parseUInt8();
-        m_btSpecObject.seconds = parser.parseUInt8();
+        bool result{true};
 
-        return true;
+        btSpecObject.year = parser.parseUInt16();
+        btSpecObject.month = parser.parseUInt8();
+        btSpecObject.day = parser.parseUInt8();
+        btSpecObject.hour = parser.parseUInt8();
+        btSpecObject.minute = parser.parseUInt8();
+        btSpecObject.seconds = parser.parseUInt8();
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/dateutc.h
+++ b/include/blevalueparser/dateutc.h
@@ -22,33 +22,33 @@ public:
     friend class BatteryInformation;
     friend class EstimatedServiceDate;
 
-    uint64_t days() const
+    BVP_GETTER(uint64_t, days, DateUTCStruct)
     {
-        return m_btSpecObject.date;
+        return btSpecObject.date;
     }
 
-    time_t date() const
+    BVP_GETTER(time_t, date, DateUTCStruct)
     {
-        return m_btSpecObject.date * secondsPerDay;
+        return btSpecObject.date * secondsPerDay;
     }
 
-    uint16_t year() const
+    BVP_GETTER(uint16_t, year, DateUTCStruct)
     {
-        time_t dt = date();
+        time_t dt = date(btSpecObject);
         tm *tm = localtime(&dt);
         return 1900 + tm->tm_year;
     }
 
-    uint8_t month() const
+    BVP_GETTER(uint8_t, month, DateUTCStruct)
     {
-        time_t dt = date();
+        time_t dt = date(btSpecObject);
         tm *tm = localtime(&dt);
         return 1 + tm->tm_mon;
     }
 
-    uint8_t day() const
+    BVP_GETTER(uint8_t, day, DateUTCStruct)
     {
-        time_t dt = date();
+        time_t dt = date(btSpecObject);
         tm *tm = localtime(&dt);
         return tm->tm_mday;
     }
@@ -63,11 +63,13 @@ private:
         return size == 3;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(DateUTCStruct)
     {
-        m_btSpecObject.date = parser.parseUInt24();
+        bool result{true};
 
-        return true;
+        btSpecObject.date = parser.parseUInt24();
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/daydatetime.h
+++ b/include/blevalueparser/daydatetime.h
@@ -22,39 +22,39 @@ class DayDateTime final : public BaseValueSpec<DayDateTimeStruct>
 public:
     friend class ExactTime256;
 
-    uint16_t year() const
+    BVP_GETTER(uint16_t, year, DayDateTimeStruct)
     {
-        return m_btSpecObject.dateTime.year;
+        return btSpecObject.dateTime.year;
     }
 
-    uint8_t month() const
+    BVP_GETTER(uint8_t, month, DayDateTimeStruct)
     {
-        return m_btSpecObject.dateTime.month;
+        return btSpecObject.dateTime.month;
     }
 
-    uint8_t day() const
+    BVP_GETTER(uint8_t, day, DayDateTimeStruct)
     {
-        return m_btSpecObject.dateTime.day;
+        return btSpecObject.dateTime.day;
     }
 
-    uint8_t hour() const
+    BVP_GETTER(uint8_t, hour, DayDateTimeStruct)
     {
-        return m_btSpecObject.dateTime.hour;
+        return btSpecObject.dateTime.hour;
     }
 
-    uint8_t minute() const
+    BVP_GETTER(uint8_t, minute, DayDateTimeStruct)
     {
-        return m_btSpecObject.dateTime.minute;
+        return btSpecObject.dateTime.minute;
     }
 
-    uint8_t seconds() const
+    BVP_GETTER(uint8_t, seconds, DayDateTimeStruct)
     {
-        return m_btSpecObject.dateTime.seconds;
+        return btSpecObject.dateTime.seconds;
     }
 
-    DayOfWeekEnum dayOfWeek() const
+    BVP_GETTER(DayOfWeekEnum, dayOfWeek, DayDateTimeStruct)
     {
-        return m_btSpecObject.dayOfWeek.dayOfWeek;
+        return btSpecObject.dayOfWeek.dayOfWeek;
     }
 
 private:
@@ -65,18 +65,20 @@ private:
         return size == 8;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(DayDateTimeStruct)
     {
-        m_btSpecObject.dateTime = DateTime(parser, configuration).getBtSpecObject();
-        m_btSpecObject.dayOfWeek = DayOfWeek(parser, configuration).getBtSpecObject();
+        bool result{true};
 
-        return true;
+        result &= DateTime::parse(parser, btSpecObject.dateTime);
+        result &= DayOfWeek::parse(parser, btSpecObject.dayOfWeek);
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override
     {
-        oss <<        DayOfWeek(m_btSpecObject.dayOfWeek, configuration);
-        oss << " " << DateTime(m_btSpecObject.dateTime, configuration);
+        oss <<        DayOfWeek(m_btSpecObject.dayOfWeek, configuration());
+        oss << " " << DateTime(m_btSpecObject.dateTime, configuration());
     }
 };
 

--- a/include/blevalueparser/dayofweek.h
+++ b/include/blevalueparser/dayofweek.h
@@ -68,9 +68,9 @@ class DayOfWeek final : public BaseValueSpec<DayOfWeekStruct>
 public:
     friend class DayDateTime;
 
-    DayOfWeekEnum dayOfWeek() const
+    BVP_GETTER(DayOfWeekEnum, dayOfWeek, DayOfWeekStruct)
     {
-        return m_btSpecObject.dayOfWeek;
+        return btSpecObject.dayOfWeek;
     }
 
 private:
@@ -81,11 +81,13 @@ private:
         return size == 1;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(DayOfWeekStruct)
     {
-        m_btSpecObject.dayOfWeek %= DayOfWeekEnum(parser.parseUInt8());
+        bool result{true};
 
-        return true;
+        btSpecObject.dayOfWeek %= DayOfWeekEnum(parser.parseUInt8());
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/dstoffset.h
+++ b/include/blevalueparser/dstoffset.h
@@ -59,9 +59,9 @@ class DSTOffset final : public BaseValueSpec<DSTOffsetStruct>
 public:
     friend class LocalTimeInformation;
 
-    DSTOffsetEnum dstOffset() const
+    BVP_GETTER(DSTOffsetEnum, dstOffset, DSTOffsetStruct)
     {
-        return m_btSpecObject.dstOffset;
+        return btSpecObject.dstOffset;
     }
 
 private:
@@ -72,11 +72,13 @@ private:
         return size == 1;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(DSTOffsetStruct)
     {
-        m_btSpecObject.dstOffset %= DSTOffsetEnum(parser.parseUInt8());
+        bool result{true};
 
-        return true;
+        btSpecObject.dstOffset %= DSTOffsetEnum(parser.parseUInt8());
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/estimatedservicedate.h
+++ b/include/blevalueparser/estimatedservicedate.h
@@ -18,29 +18,29 @@ struct EstimatedServiceDateStruct
 class EstimatedServiceDate final : public BaseValueSpec<EstimatedServiceDateStruct>
 {
 public:
-    uint64_t days() const
+    BVP_GETTER(uint64_t, days, EstimatedServiceDateStruct)
     {
-        return DateUTC(m_btSpecObject.estimatedServiceDate, configuration).days();
+        return DateUTC::days(btSpecObject.estimatedServiceDate);
     }
 
-    time_t date() const
+    BVP_GETTER(time_t, date, EstimatedServiceDateStruct)
     {
-        return DateUTC(m_btSpecObject.estimatedServiceDate, configuration).date();
+        return DateUTC::date(btSpecObject.estimatedServiceDate);
     }
 
-    uint16_t year() const
+    BVP_GETTER(uint16_t, year, EstimatedServiceDateStruct)
     {
-        return DateUTC(m_btSpecObject.estimatedServiceDate, configuration).year();
+        return DateUTC::year(btSpecObject.estimatedServiceDate);
     }
 
-    uint8_t month() const
+    BVP_GETTER(uint8_t, month, EstimatedServiceDateStruct)
     {
-        return DateUTC(m_btSpecObject.estimatedServiceDate, configuration).month();
+        return DateUTC::month(btSpecObject.estimatedServiceDate);
     }
 
-    uint8_t day() const
+    BVP_GETTER(uint8_t, day, EstimatedServiceDateStruct)
     {
-        return DateUTC(m_btSpecObject.estimatedServiceDate, configuration).day();
+        return DateUTC::day(btSpecObject.estimatedServiceDate);
     }
 
 private:
@@ -51,16 +51,18 @@ private:
         return size == 3;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(EstimatedServiceDateStruct)
     {
-        m_btSpecObject.estimatedServiceDate = DateUTC(parser, configuration).getBtSpecObject();
+        bool result{true};
 
-        return true;
+        result &= DateUTC::parse(parser, btSpecObject.estimatedServiceDate);
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override
     {
-        oss << DateUTC(m_btSpecObject.estimatedServiceDate, configuration);
+        oss << DateUTC(m_btSpecObject.estimatedServiceDate, configuration());
     }
 };
 

--- a/include/blevalueparser/exacttime256.h
+++ b/include/blevalueparser/exacttime256.h
@@ -21,49 +21,49 @@ class ExactTime256 final : public BaseValueSpec<ExactTime256Struct>
 public:
     friend class CurrentTime;
 
-    uint16_t year() const
+    BVP_GETTER(uint16_t, year, ExactTime256Struct)
     {
-        return m_btSpecObject.dayDateTime.dateTime.year;
+        return btSpecObject.dayDateTime.dateTime.year;
     }
 
-    uint8_t month() const
+    BVP_GETTER(uint8_t, month, ExactTime256Struct)
     {
-        return m_btSpecObject.dayDateTime.dateTime.month;
+        return btSpecObject.dayDateTime.dateTime.month;
     }
 
-    uint8_t day() const
+    BVP_GETTER(uint8_t, day, ExactTime256Struct)
     {
-        return m_btSpecObject.dayDateTime.dateTime.day;
+        return btSpecObject.dayDateTime.dateTime.day;
     }
 
-    uint8_t hour() const
+    BVP_GETTER(uint8_t, hour, ExactTime256Struct)
     {
-        return m_btSpecObject.dayDateTime.dateTime.hour;
+        return btSpecObject.dayDateTime.dateTime.hour;
     }
 
-    uint8_t minute() const
+    BVP_GETTER(uint8_t, minute, ExactTime256Struct)
     {
-        return m_btSpecObject.dayDateTime.dateTime.minute;
+        return btSpecObject.dayDateTime.dateTime.minute;
     }
 
-    uint8_t seconds() const
+    BVP_GETTER(uint8_t, seconds, ExactTime256Struct)
     {
-        return m_btSpecObject.dayDateTime.dateTime.seconds;
+        return btSpecObject.dayDateTime.dateTime.seconds;
     }
 
-    DayOfWeekEnum dayOfWeek() const
+    BVP_GETTER(DayOfWeekEnum, dayOfWeek, ExactTime256Struct)
     {
-        return m_btSpecObject.dayDateTime.dayOfWeek.dayOfWeek;
+        return btSpecObject.dayDateTime.dayOfWeek.dayOfWeek;
     }
 
-    uint8_t fractionsOfSeconds() const
+    BVP_GETTER(uint8_t, fractionsOfSeconds, ExactTime256Struct)
     {
-        return m_btSpecObject.fractions256;
+        return btSpecObject.fractions256;
     }
 
-    uint16_t milliseconds() const
+    BVP_GETTER(uint16_t, milliseconds, ExactTime256Struct)
     {
-        return m_btSpecObject.fractions256 * 1000 / 256;
+        return btSpecObject.fractions256 * 1000 / 256;
     }
 
 private:
@@ -74,17 +74,19 @@ private:
         return size == 9;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(ExactTime256Struct)
     {
-        m_btSpecObject.dayDateTime = DayDateTime(parser, configuration).getBtSpecObject();
-        m_btSpecObject.fractions256 = parser.parseUInt8();
+        bool result{true};
 
-        return true;
+        result &= DayDateTime::parse(parser, btSpecObject.dayDateTime);
+        btSpecObject.fractions256 = parser.parseUInt8();
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override
     {
-        oss <<        DayDateTime(m_btSpecObject.dayDateTime, configuration);
+        oss <<        DayDateTime(m_btSpecObject.dayDateTime, configuration());
         oss << "." << std::setfill('0') << std::setw(3) << static_cast<int>(milliseconds());
     }
 };

--- a/include/blevalueparser/heartratecontrolpoint.h
+++ b/include/blevalueparser/heartratecontrolpoint.h
@@ -51,9 +51,9 @@ struct HeartRateControlPointStruct
 class HeartRateControlPoint final : public BaseValueSpec<HeartRateControlPointStruct>
 {
 public:
-    HeartRateControlPointEnum controlPointType() const
+    BVP_GETTER(HeartRateControlPointEnum, controlPointType, HeartRateControlPointStruct)
     {
-        return m_btSpecObject.heartRateControlPoint;
+        return btSpecObject.heartRateControlPoint;
     }
 
 private:
@@ -64,11 +64,13 @@ private:
         return size == 1;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(HeartRateControlPointStruct)
     {
-        m_btSpecObject.heartRateControlPoint %= HeartRateControlPointEnum(parser.parseUInt8());
+        bool result{true};
 
-        return true;
+        btSpecObject.heartRateControlPoint %= HeartRateControlPointEnum(parser.parseUInt8());
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/localtimeinformation.h
+++ b/include/blevalueparser/localtimeinformation.h
@@ -22,14 +22,14 @@ struct LocalTimeInformationStruct
 class LocalTimeInformation final : public BaseValueSpec<LocalTimeInformationStruct>
 {
 public:
-    TimeZoneEnum timeZone() const
+    BVP_GETTER(TimeZoneEnum, timeZone, LocalTimeInformationStruct)
     {
-        return m_btSpecObject.timeZone.timeZone;
+        return btSpecObject.timeZone.timeZone;
     }
 
-    DSTOffsetEnum dstOffset() const
+    BVP_GETTER(DSTOffsetEnum, dstOffset, LocalTimeInformationStruct)
     {
-        return m_btSpecObject.dstOffset.dstOffset;
+        return btSpecObject.dstOffset.dstOffset;
     }
 
 private:
@@ -40,18 +40,20 @@ private:
         return size == 2;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(LocalTimeInformationStruct)
     {
-        m_btSpecObject.timeZone = TimeZone(parser, configuration).getBtSpecObject();
-        m_btSpecObject.dstOffset = DSTOffset(parser, configuration).getBtSpecObject();
+        bool result{true};
 
-        return true;
+        result &= TimeZone::parse(parser, btSpecObject.timeZone);
+        result &= DSTOffset::parse(parser, btSpecObject.dstOffset);
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override
     {
-        oss <<   "TZ: "  << TimeZone(m_btSpecObject.timeZone, configuration);
-        oss << ", DST: " << DSTOffset(m_btSpecObject.dstOffset, configuration);
+        oss <<   "TZ: "  << TimeZone(m_btSpecObject.timeZone, configuration());
+        oss << ", DST: " << DSTOffset(m_btSpecObject.dstOffset, configuration());
     }
 };
 

--- a/include/blevalueparser/newalert.h
+++ b/include/blevalueparser/newalert.h
@@ -22,31 +22,19 @@ struct NewAlertStruct
 class NewAlert final : public BaseValueSpec<NewAlertStruct>
 {
 public:
-    static AlertCategoryIDEnum categoryID(const NewAlertStruct &btSpecObject)
+    BVP_GETTER(AlertCategoryIDEnum, categoryID, NewAlertStruct)
     {
         return btSpecObject.categoryID.categoryID;
     }
-    AlertCategoryIDEnum categoryID() const
-    {
-        return categoryID(m_btSpecObject);
-    }
 
-    static uint8_t numberOfNewAlert(const NewAlertStruct &btSpecObject)
+    BVP_GETTER(uint8_t, numberOfNewAlert, NewAlertStruct)
     {
         return btSpecObject.numberOfNewAlert;
     }
-    uint8_t numberOfNewAlert() const
-    {
-        return numberOfNewAlert(m_btSpecObject);
-    }
 
-    static std::string recentAlertBrief(const NewAlertStruct &btSpecObject)
+    BVP_GETTER(std::string, recentAlertBrief, NewAlertStruct)
     {
         return btSpecObject.textStringInformation;
-    }
-    std::string recentAlertBrief() const
-    {
-        return recentAlertBrief(m_btSpecObject);
     }
 
 private:
@@ -57,7 +45,7 @@ private:
         return size > 1 && size < 21;
     }
 
-    static bool parse(Parser &parser, NewAlertStruct &btSpecObject)
+    BVP_PARSE(NewAlertStruct)
     {
         bool result{true};
 
@@ -66,10 +54,6 @@ private:
         btSpecObject.textStringInformation = parser.parseString();
 
         return result;
-    }
-    virtual bool parse(Parser &parser) override
-    {
-        return parse(parser, m_btSpecObject);
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/pnpid.h
+++ b/include/blevalueparser/pnpid.h
@@ -66,34 +66,34 @@ struct PnPIDStruct
 class PnPID final : public BaseValueSpec<PnPIDStruct>
 {
 public:
-    VendorIdSourceEnum vendorIdSource() const
+    BVP_GETTER(VendorIdSourceEnum, vendorIdSource, PnPIDStruct)
     {
-        return m_btSpecObject.vendorIdSource.vendorIdSource;
+        return btSpecObject.vendorIdSource.vendorIdSource;
     }
 
-    uint16_t vendorId() const
+    BVP_GETTER(uint16_t, vendorId, PnPIDStruct)
     {
-        return m_btSpecObject.vendorId;
+        return btSpecObject.vendorId;
     }
 
-    uint16_t productId() const
+    BVP_GETTER(uint16_t, productId, PnPIDStruct)
     {
-        return m_btSpecObject.productId;
+        return btSpecObject.productId;
     }
 
-    uint8_t majorVersion() const
+    BVP_GETTER(uint8_t, majorVersion, PnPIDStruct)
     {
-        return m_btSpecObject.productVersion >> 8;
+        return btSpecObject.productVersion >> 8;
     }
 
-    uint8_t minorVersion() const
+    BVP_GETTER(uint8_t, minorVersion, PnPIDStruct)
     {
-        return m_btSpecObject.productVersion >> 4 & 0b1111;
+        return btSpecObject.productVersion >> 4 & 0b1111;
     }
 
-    uint8_t subMinorVersion() const
+    BVP_GETTER(uint8_t, subMinorVersion, PnPIDStruct)
     {
-        return m_btSpecObject.productVersion & 0b1111;
+        return btSpecObject.productVersion & 0b1111;
     }
 
 private:
@@ -104,21 +104,23 @@ private:
         return size == 7;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(PnPIDStruct)
     {
+        bool result{true};
+
         // 3.9.1.1 Vendor ID Source Field
-        m_btSpecObject.vendorIdSource.vendorIdSource %= VendorIdSourceEnum(parser.parseUInt8());
+        btSpecObject.vendorIdSource.vendorIdSource %= VendorIdSourceEnum(parser.parseUInt8());
         // 3.9.1.2 Vendor ID Field
-        m_btSpecObject.vendorId = parser.parseUInt16();
+        btSpecObject.vendorId = parser.parseUInt16();
         // 3.9.1.3 Product ID Field
-        m_btSpecObject.productId = parser.parseUInt16();
+        btSpecObject.productId = parser.parseUInt16();
 
         // 3.9.1.4 Product Version Field
         // The value of the field value is 0xJJMN for version JJ.M.N
         // (JJ – major version number, M – minor version number, N – sub-minor version number)
-        m_btSpecObject.productVersion = parser.parseUInt16();
+        btSpecObject.productVersion = parser.parseUInt16();
 
-        return true;
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/supportedalertcategorybase.h
+++ b/include/blevalueparser/supportedalertcategorybase.h
@@ -24,94 +24,54 @@ struct SupportedAlertCategoryBaseStruct
 class SupportedAlertCategoryBase : public BaseValueSpec<SupportedAlertCategoryBaseStruct>
 {
 public:
-    static bool isSimpleAlertSupported(const SupportedAlertCategoryBaseStruct &btSpecObject)
+    BVP_GETTER(bool, isSimpleAlertSupported, SupportedAlertCategoryBaseStruct)
     {
         return AlertCategoryIDBitMask::hasSimpleAlert(btSpecObject.categoryIDBitMask);
     }
-    bool isSimpleAlertSupported() const
-    {
-        return isSimpleAlertSupported(m_btSpecObject);
-    }
 
-    static bool isEmailSupported(const SupportedAlertCategoryBaseStruct &btSpecObject)
+    BVP_GETTER(bool, isEmailSupported, SupportedAlertCategoryBaseStruct)
     {
         return AlertCategoryIDBitMask::hasEmail(btSpecObject.categoryIDBitMask);
     }
-    bool isEmailSupported() const
-    {
-        return isEmailSupported(m_btSpecObject);
-    }
 
-    static bool isNewsSupported(const SupportedAlertCategoryBaseStruct &btSpecObject)
+    BVP_GETTER(bool, isNewsSupported, SupportedAlertCategoryBaseStruct)
     {
         return AlertCategoryIDBitMask::hasNews(btSpecObject.categoryIDBitMask);
     }
-    bool isNewsSupported() const
-    {
-        return isNewsSupported(m_btSpecObject);
-    }
 
-    static bool isCallSupported(const SupportedAlertCategoryBaseStruct &btSpecObject)
+    BVP_GETTER(bool, isCallSupported, SupportedAlertCategoryBaseStruct)
     {
         return AlertCategoryIDBitMask::hasCall(btSpecObject.categoryIDBitMask);
     }
-    bool isCallSupported() const
-    {
-        return isCallSupported(m_btSpecObject);
-    }
 
-    static bool isMissedCallSupported(const SupportedAlertCategoryBaseStruct &btSpecObject)
+    BVP_GETTER(bool, isMissedCallSupported, SupportedAlertCategoryBaseStruct)
     {
         return AlertCategoryIDBitMask::hasMissedCall(btSpecObject.categoryIDBitMask);
     }
-    bool isMissedCallSupported() const
-    {
-        return isMissedCallSupported(m_btSpecObject);
-    }
 
-    static bool isSMSMMSSupported(const SupportedAlertCategoryBaseStruct &btSpecObject)
+    BVP_GETTER(bool, isSMSMMSSupported, SupportedAlertCategoryBaseStruct)
     {
         return AlertCategoryIDBitMask::hasSMSMMS(btSpecObject.categoryIDBitMask);
     }
-    bool isSMSMMSSupported() const
-    {
-        return isSMSMMSSupported(m_btSpecObject);
-    }
 
-    static bool isVoiceMailSupported(const SupportedAlertCategoryBaseStruct &btSpecObject)
+    BVP_GETTER(bool, isVoiceMailSupported, SupportedAlertCategoryBaseStruct)
     {
         return AlertCategoryIDBitMask::hasVoiceMail(btSpecObject.categoryIDBitMask);
     }
-    bool isVoiceMailSupported() const
-    {
-        return isVoiceMailSupported(m_btSpecObject);
-    }
 
-    static bool isScheduleSupported(const SupportedAlertCategoryBaseStruct &btSpecObject)
+    BVP_GETTER(bool, isScheduleSupported, SupportedAlertCategoryBaseStruct)
     {
         return AlertCategoryIDBitMask::hasSchedule(btSpecObject.categoryIDBitMask);
     }
-    bool isScheduleSupported() const
-    {
-        return isScheduleSupported(m_btSpecObject);
-    }
 
-    static bool isHighPrioritizedAlertSupported(const SupportedAlertCategoryBaseStruct &btSpecObject)
+    BVP_GETTER(bool, isHighPrioritizedAlertSupported, SupportedAlertCategoryBaseStruct)
     {
         return AlertCategoryIDBitMask::hasHighPrioritizedAlert(btSpecObject.categoryIDBitMask);
     }
-    bool isHighPrioritizedAlertSupported() const
-    {
-        return isHighPrioritizedAlertSupported(m_btSpecObject);
-    }
 
-    static bool isInstantMessageSupported(const SupportedAlertCategoryBaseStruct &btSpecObject)
+    BVP_GETTER(bool, isInstantMessageSupported, SupportedAlertCategoryBaseStruct)
     {
         return AlertCategoryIDBitMask::hasInstantMessage(btSpecObject.categoryIDBitMask);
-    }
-    bool isInstantMessageSupported() const
-    {
-        return isInstantMessageSupported(m_btSpecObject);
     }
 
 protected:
@@ -128,7 +88,7 @@ protected:
         return size == 2;
     }
 
-    static bool parse(Parser &parser, SupportedAlertCategoryBaseStruct &btSpecObject)
+    BVP_PARSE(SupportedAlertCategoryBaseStruct)
     {
         bool result{true};
 
@@ -136,14 +96,10 @@ protected:
 
         return result;
     }
-    virtual bool parse(Parser &parser) override
-    {
-        return parse(parser, m_btSpecObject);
-    }
 
     virtual void toStringStream(std::ostringstream &oss) const override
     {
-        oss << "SupportedCategories: " << AlertCategoryIDBitMask(m_btSpecObject.categoryIDBitMask, configuration);
+        oss << "SupportedCategories: " << AlertCategoryIDBitMask(m_btSpecObject.categoryIDBitMask, configuration());
     }
 };
 

--- a/include/blevalueparser/textstring.h
+++ b/include/blevalueparser/textstring.h
@@ -14,9 +14,9 @@ struct TextStringStruct
 class TextString final : public BaseValueSpec<TextStringStruct>
 {
 public:
-    std::string textString() const
+    BVP_GETTER(std::string, textString, TextStringStruct)
     {
-        return m_btSpecObject.textString;
+        return btSpecObject.textString;
     }
 
 private:
@@ -28,10 +28,13 @@ private:
         return true;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(TextStringStruct)
     {
-        m_btSpecObject.textString = parser.parseString();
-        return true;
+        bool result{true};
+
+        btSpecObject.textString = parser.parseString();
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/timeaccuracy.h
+++ b/include/blevalueparser/timeaccuracy.h
@@ -19,28 +19,28 @@ class TimeAccuracy final : public BaseValueSpec<TimeAccuracyStruct>
 public:
     friend class ReferenceTimeInformation;
 
-    bool isLarger() const
+    BVP_GETTER(bool, isLarger, TimeAccuracyStruct)
     {
         // A value of 254 means drift is larger than 31.625s.
-        return m_btSpecObject.accuracy == s_timeAccuracyLarge;
+        return btSpecObject.accuracy == s_timeAccuracyLarge;
     }
 
-    bool isUnknown() const
+    BVP_GETTER(bool, isUnknown, TimeAccuracyStruct)
     {
         // A value of 255 means drift is unknown.
-        return m_btSpecObject.accuracy == s_timeAccuracyUnknown;
+        return btSpecObject.accuracy == s_timeAccuracyUnknown;
     }
 
-    uint16_t accuracyMs() const
+    BVP_GETTER(uint16_t, accuracyMs, TimeAccuracyStruct)
     {
-        if (m_btSpecObject.accuracy >= s_timeAccuracyLarge)
+        if (btSpecObject.accuracy >= s_timeAccuracyLarge)
         {
             return UINT16_MAX;
         }
 
         // This field represents accuracy (drift) of time information
         // in steps of 1/8 of a second (125ms) compared to a reference time source.
-        return m_btSpecObject.accuracy * 125;
+        return btSpecObject.accuracy * 125;
     }
 
 private:
@@ -54,11 +54,13 @@ private:
         return size == 1;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(TimeAccuracyStruct)
     {
-        m_btSpecObject.accuracy = parser.parseUInt8();
+        bool result{true};
 
-        return true;
+        btSpecObject.accuracy = parser.parseUInt8();
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/timesource.h
+++ b/include/blevalueparser/timesource.h
@@ -64,9 +64,9 @@ class TimeSource final : public BaseValueSpec<TimeSourceStruct>
 public:
     friend class ReferenceTimeInformation;
 
-    TimeSourceEnum timeSource() const
+    BVP_GETTER(TimeSourceEnum, timeSource, TimeSourceStruct)
     {
-        return m_btSpecObject.timeSource;
+        return btSpecObject.timeSource;
     }
 
 private:
@@ -77,11 +77,13 @@ private:
         return size == 1;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(TimeSourceStruct)
     {
-        m_btSpecObject.timeSource %= TimeSourceEnum(parser.parseUInt8());
+        bool result{true};
 
-        return true;
+        btSpecObject.timeSource %= TimeSourceEnum(parser.parseUInt8());
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/timezone.h
+++ b/include/blevalueparser/timezone.h
@@ -252,9 +252,9 @@ class TimeZone final : public BaseValueSpec<TimeZoneStruct>
 public:
     friend class LocalTimeInformation;
 
-    TimeZoneEnum timeZone() const
+    BVP_GETTER(TimeZoneEnum, timeZone, TimeZoneStruct)
     {
-        return m_btSpecObject.timeZone;
+        return btSpecObject.timeZone;
     }
 
 private:
@@ -265,11 +265,13 @@ private:
         return size == 1;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(TimeZoneStruct)
     {
-        m_btSpecObject.timeZone %= TimeZoneEnum(parser.parseInt8());
+        bool result{true};
 
-        return true;
+        btSpecObject.timeZone %= TimeZoneEnum(parser.parseInt8());
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/unreadalertstatus.h
+++ b/include/blevalueparser/unreadalertstatus.h
@@ -21,31 +21,19 @@ struct UnreadAlertStatusStruct
 class UnreadAlertStatus final : public BaseValueSpec<UnreadAlertStatusStruct>
 {
 public:
-    static AlertCategoryIDEnum categoryID(const UnreadAlertStatusStruct &btSpecObject)
+    BVP_GETTER(AlertCategoryIDEnum, categoryID, UnreadAlertStatusStruct)
     {
         return btSpecObject.categoryID.categoryID;
     }
-    AlertCategoryIDEnum categoryID() const
-    {
-        return categoryID(m_btSpecObject);
-    }
 
-    static uint8_t unreadCount(const UnreadAlertStatusStruct &btSpecObject)
+    BVP_GETTER(uint8_t, unreadCount, UnreadAlertStatusStruct)
     {
         return btSpecObject.unreadCount;
     }
-    uint8_t unreadCount() const
-    {
-        return unreadCount(m_btSpecObject);
-    }
 
-    static bool isUnreadCountGreater(const UnreadAlertStatusStruct &btSpecObject)
+    BVP_GETTER(bool, isUnreadCountGreater, UnreadAlertStatusStruct)
     {
         return s_greater == btSpecObject.unreadCount;
-    }
-    bool isUnreadCountGreater() const
-    {
-        return isUnreadCountGreater(m_btSpecObject);
     }
 
 private:
@@ -59,7 +47,7 @@ private:
         return size == 2;
     }
 
-    static bool parse(Parser &parser, UnreadAlertStatusStruct &btSpecObject)
+    BVP_PARSE(UnreadAlertStatusStruct)
     {
         bool result{true};
 
@@ -67,10 +55,6 @@ private:
         btSpecObject.unreadCount = parser.parseUInt8();
 
         return result;
-    }
-    virtual bool parse(Parser &parser) override
-    {
-        return parse(parser, m_btSpecObject);
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/include/blevalueparser/userindex.h
+++ b/include/blevalueparser/userindex.h
@@ -19,9 +19,9 @@ class UserIndex final : public BaseValueSpec<UserIndexStruct>
 public:
     friend class BodyCompositionMeasurement;
 
-    uint8_t userIndex() const
+    BVP_GETTER(uint8_t, userIndex, UserIndexStruct)
     {
-        return m_btSpecObject.userIndex;
+        return btSpecObject.userIndex;
     }
 
 private:
@@ -32,11 +32,13 @@ private:
         return size == 1;
     }
 
-    virtual bool parse(Parser &parser) override
+    BVP_PARSE(UserIndexStruct)
     {
-        m_btSpecObject.userIndex = parser.parseUInt8();
+        bool result{true};
 
-        return true;
+        btSpecObject.userIndex = parser.parseUInt8();
+
+        return result;
     }
 
     virtual void toStringStream(std::ostringstream &oss) const override

--- a/tests/bodycompositionfeaturetest.cpp
+++ b/tests/bodycompositionfeaturetest.cpp
@@ -8,9 +8,16 @@
 namespace bvp
 {
 
-struct BodyCompositionFeatureTest : public testing::Test
+class BodyCompositionFeatureTest : public testing::Test
 {
+public:
+    BodyCompositionFeatureTest()
+    {
+        bleValueParserImperial.configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    }
+
     BLEValueParser bleValueParser;
+    BLEValueParser bleValueParserImperial;
 };
 
 TEST_F(BodyCompositionFeatureTest, FeaturesAll_WeightResNotSpec_HeightResNotSpec_ReservedEven)
@@ -41,7 +48,7 @@ TEST_F(BodyCompositionFeatureTest, FeaturesAll_WeightResNotSpec_HeightResNotSpec
 
     EXPECT_EQ("Features: { TimeStamp MultipleUsers BasalMetabolism MusclePercentage MuscleMass FatFreeMass SoftLeanMass BodyWaterMass Impedance Weight Height }, WeightResolution: 0kg, HeightResolution: 0m", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    result = bleValueParserImperial.make_value<BodyCompositionFeature>(data, sizeof(data));
     EXPECT_EQ(0, result->weightResolution());
     EXPECT_EQ(0, result->heightResolution());
     EXPECT_EQ("Features: { TimeStamp MultipleUsers BasalMetabolism MusclePercentage MuscleMass FatFreeMass SoftLeanMass BodyWaterMass Impedance Weight Height }, WeightResolution: 0lb, HeightResolution: 0in", result->toString());
@@ -75,7 +82,7 @@ TEST_F(BodyCompositionFeatureTest, FeaturesNone_WeightRes0500_HeightRes0010_Rese
 
     EXPECT_EQ("Features: { }", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    result = bleValueParserImperial.make_value<BodyCompositionFeature>(data, sizeof(data));
     EXPECT_EQ(1000, result->weightResolution());
     EXPECT_EQ(1000, result->heightResolution());
     EXPECT_EQ("Features: { }", result->toString());
@@ -109,7 +116,7 @@ TEST_F(BodyCompositionFeatureTest, FeaturesEven_WeightRes0200_HeightRes0005_Rese
 
     EXPECT_EQ("Features: { MultipleUsers MusclePercentage FatFreeMass BodyWaterMass Weight }, WeightResolution: 0.2kg", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    result = bleValueParserImperial.make_value<BodyCompositionFeature>(data, sizeof(data));
     EXPECT_EQ(500, result->weightResolution());
     EXPECT_EQ(500, result->heightResolution());
     EXPECT_EQ("Features: { MultipleUsers MusclePercentage FatFreeMass BodyWaterMass Weight }, WeightResolution: 0.5lb", result->toString());
@@ -143,7 +150,7 @@ TEST_F(BodyCompositionFeatureTest, FeaturesOdd_WeightRes0100_HeightRes0001_Reser
 
     EXPECT_EQ("Features: { TimeStamp BasalMetabolism MuscleMass SoftLeanMass Impedance Height }, HeightResolution: 0.001m", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    result = bleValueParserImperial.make_value<BodyCompositionFeature>(data, sizeof(data));
     EXPECT_EQ(200, result->weightResolution());
     EXPECT_EQ(100, result->heightResolution());
     EXPECT_EQ("Features: { TimeStamp BasalMetabolism MuscleMass SoftLeanMass Impedance Height }, HeightResolution: 0.1in", result->toString());
@@ -177,7 +184,7 @@ TEST_F(BodyCompositionFeatureTest, FeaturesPat1_WeightRes0050_HeightResReserved_
 
     EXPECT_EQ("Features: { TimeStamp MultipleUsers MusclePercentage MuscleMass SoftLeanMass BodyWaterMass Weight Height }, WeightResolution: 0.05kg, HeightResolution: 0m", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    result = bleValueParserImperial.make_value<BodyCompositionFeature>(data, sizeof(data));
     EXPECT_EQ(100, result->weightResolution());
     EXPECT_EQ(0, result->heightResolution());
     EXPECT_EQ("Features: { TimeStamp MultipleUsers MusclePercentage MuscleMass SoftLeanMass BodyWaterMass Weight Height }, WeightResolution: 0.1lb, HeightResolution: 0in", result->toString());
@@ -211,7 +218,7 @@ TEST_F(BodyCompositionFeatureTest, FeaturesPat2_WeightRes0020_HeightRes0001_Rese
 
     EXPECT_EQ("Features: { BasalMetabolism FatFreeMass Impedance }", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    result = bleValueParserImperial.make_value<BodyCompositionFeature>(data, sizeof(data));
     EXPECT_EQ(50, result->weightResolution());
     EXPECT_EQ(100, result->heightResolution());
     EXPECT_EQ("Features: { BasalMetabolism FatFreeMass Impedance }", result->toString());
@@ -245,7 +252,7 @@ TEST_F(BodyCompositionFeatureTest, FeaturesPat3_WeightRes0010_HeightRes0005_Rese
 
     EXPECT_EQ("Features: { BasalMetabolism MuscleMass FatFreeMass BodyWaterMass Impedance Weight }, WeightResolution: 0.01kg", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    result = bleValueParserImperial.make_value<BodyCompositionFeature>(data, sizeof(data));
     EXPECT_EQ(20, result->weightResolution());
     EXPECT_EQ(500, result->heightResolution());
     EXPECT_EQ("Features: { BasalMetabolism MuscleMass FatFreeMass BodyWaterMass Impedance Weight }, WeightResolution: 0.02lb", result->toString());
@@ -279,7 +286,7 @@ TEST_F(BodyCompositionFeatureTest, FeaturesPat4_WeightRes0005_HeightRes0010_Rese
 
     EXPECT_EQ("Features: { MultipleUsers BasalMetabolism MusclePercentage FatFreeMass SoftLeanMass Impedance }", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    result = bleValueParserImperial.make_value<BodyCompositionFeature>(data, sizeof(data));
     EXPECT_EQ(10, result->weightResolution());
     EXPECT_EQ(1000, result->heightResolution());
     EXPECT_EQ("Features: { MultipleUsers BasalMetabolism MusclePercentage FatFreeMass SoftLeanMass Impedance }", result->toString());
@@ -313,7 +320,7 @@ TEST_F(BodyCompositionFeatureTest, FeaturesPat5_WeightResReserved_HeightResNotSp
 
     EXPECT_EQ("Features: { TimeStamp MusclePercentage MuscleMass BodyWaterMass Impedance }", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    result = bleValueParserImperial.make_value<BodyCompositionFeature>(data, sizeof(data));
     EXPECT_EQ(0, result->weightResolution());
     EXPECT_EQ(0, result->heightResolution());
     EXPECT_EQ("Features: { TimeStamp MusclePercentage MuscleMass BodyWaterMass Impedance }", result->toString());

--- a/tests/bodycompositionmeasurementmibfstest.cpp
+++ b/tests/bodycompositionmeasurementmibfstest.cpp
@@ -17,7 +17,7 @@ TEST_F(BodyCompositionMeasurementMIBFSTest, NoImpendance_Unstable_Loaded)
 {
     //                             RRRMFFFF       FFFFFFFU
     constexpr char flags[] = { C(0b00000100), C(0b00000010) };
-    constexpr char data[] = {
+    char data[] = {
         flags[1], flags[0],
         '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
         '\x12', '\x34',                                         // impedance
@@ -81,7 +81,8 @@ TEST_F(BodyCompositionMeasurementMIBFSTest, NoImpendance_Unstable_Loaded)
 
     EXPECT_EQ("Unstable, TimeStamp: 06.02.2023 18:28:00, Weight: 154.03kg", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    data[0] |= 1;  // Imperial
+    result = bleValueParser.make_value<BodyCompositionMeasurementMIBFS>(data, sizeof(data));
     EXPECT_FLOAT_EQ(0.0, result->bodyFatPercentage());
     EXPECT_EQ(2023, result->year());
     EXPECT_EQ(02, result->month());
@@ -106,7 +107,7 @@ TEST_F(BodyCompositionMeasurementMIBFSTest, HasImpendance_Stabilized_Loaded)
 {
     //                             RRRMFFFF       FFFFFFFU
     constexpr char flags[] = { C(0b00100110), C(0b00000010) };
-    constexpr char data[] = {
+    char data[] = {
         flags[1], flags[0],
         '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
         '\x12', '\x34',                                         // impedance
@@ -170,7 +171,8 @@ TEST_F(BodyCompositionMeasurementMIBFSTest, HasImpendance_Stabilized_Loaded)
 
     EXPECT_EQ("Stabilized, TimeStamp: 06.02.2023 18:28:00, Impedance: 1333Ω, Weight: 154.03kg", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    data[0] |= 1;  // Imperial
+    result = bleValueParser.make_value<BodyCompositionMeasurementMIBFS>(data, sizeof(data));
     EXPECT_FLOAT_EQ(0.0, result->bodyFatPercentage());
     EXPECT_EQ(2023, result->year());
     EXPECT_EQ(02, result->month());
@@ -195,7 +197,7 @@ TEST_F(BodyCompositionMeasurementMIBFSTest, NoImpendance_Unstable_Unloaded)
 {
     //                             RRRMFFFF       FFFFFFFU
     constexpr char flags[] = { C(0b10000100), C(0b00000010) };
-    constexpr char data[] = {
+    char data[] = {
         flags[1], flags[0],
         '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
         '\x12', '\x34',                                         // impedance
@@ -259,7 +261,8 @@ TEST_F(BodyCompositionMeasurementMIBFSTest, NoImpendance_Unstable_Unloaded)
 
     EXPECT_EQ("Unloaded, TimeStamp: 06.02.2023 18:28:00, Weight: 154.03kg", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    data[0] |= 1;  // Imperial
+    result = bleValueParser.make_value<BodyCompositionMeasurementMIBFS>(data, sizeof(data));
     EXPECT_FLOAT_EQ(0.0, result->bodyFatPercentage());
     EXPECT_EQ(2023, result->year());
     EXPECT_EQ(02, result->month());
@@ -284,7 +287,7 @@ TEST_F(BodyCompositionMeasurementMIBFSTest, HasImpendance_Stabilized_Unloaded)
 {
     //                             RRRMFFFF       FFFFFFFU
     constexpr char flags[] = { C(0b10100110), C(0b00000010) };
-    constexpr char data[] = {
+    char data[] = {
         flags[1], flags[0],
         '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
         '\x12', '\x34',                                         // impedance
@@ -348,7 +351,8 @@ TEST_F(BodyCompositionMeasurementMIBFSTest, HasImpendance_Stabilized_Unloaded)
 
     EXPECT_EQ("Unloaded, TimeStamp: 06.02.2023 18:28:00, Impedance: 1333Ω, Weight: 154.03kg", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    data[0] |= 1;  // Imperial
+    result = bleValueParser.make_value<BodyCompositionMeasurementMIBFS>(data, sizeof(data));
     EXPECT_FLOAT_EQ(0.0, result->bodyFatPercentage());
     EXPECT_EQ(2023, result->year());
     EXPECT_EQ(02, result->month());

--- a/tests/bodycompositionmeasurementtest.cpp
+++ b/tests/bodycompositionmeasurementtest.cpp
@@ -17,7 +17,7 @@ TEST_F(BodyCompositionMeasurementTest, FeaturesAll_SinglePacket_ReservedOdd)
 {
     //                             RRRMFFFF       FFFFFFFU
     constexpr char flags[] = { C(0b10101111), C(0b11111110) };
-    constexpr char data[] = {
+    char data[] = {
         flags[1], flags[0],
         '\x12', '\x34',                                         // bodyFatPercentage
         '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
@@ -90,7 +90,8 @@ TEST_F(BodyCompositionMeasurementTest, FeaturesAll_SinglePacket_ReservedOdd)
 
     EXPECT_EQ("BodyFatPercentage: 1333%, TimeStamp: 06.02.2023 18:28:00, UserID: 42, BasalMetabolism: 17699kJ, MusclePercentage: 2206.8%, MuscleMass: 132.185kg, FatFreeMass: 154.03kg, SoftLeanMass: 175.875kg, BodyWaterMass: 197.72kg, Impedance: 4391.3Ω, Weight: 241.41kg, Height: 52.651m", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    data[0] |= 1;  // Imperial
+    result = bleValueParser.make_value<BodyCompositionMeasurement>(data, sizeof(data));
     EXPECT_FLOAT_EQ(1333.0, result->bodyFatPercentage());
     EXPECT_EQ(2023, result->year());
     EXPECT_EQ(02, result->month());
@@ -115,7 +116,7 @@ TEST_F(BodyCompositionMeasurementTest, FeaturesNone_MultiplePacket_ReservedEven)
 {
     //                             RRRMFFFF       FFFFFFFU
     constexpr char flags[] = { C(0b01010000), C(0b00000000) };
-    constexpr char data[] = {
+    char data[] = {
         flags[1], flags[0],
         '\x12', '\x34'                                          // bodyFatPercentage
     };
@@ -177,7 +178,8 @@ TEST_F(BodyCompositionMeasurementTest, FeaturesNone_MultiplePacket_ReservedEven)
 
     EXPECT_EQ("BodyFatPercentage: 1333%", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    data[0] |= 1;  // Imperial
+    result = bleValueParser.make_value<BodyCompositionMeasurement>(data, sizeof(data));
     EXPECT_FLOAT_EQ(1333.0, result->bodyFatPercentage());
     EXPECT_EQ(0, result->year());
     EXPECT_EQ(0, result->month());
@@ -202,7 +204,7 @@ TEST_F(BodyCompositionMeasurementTest, FeaturesOdd_SinglePacket_ReservedAll)
 {
     //                             RRRMFFFF       FFFFFFFU
     constexpr char flags[] = { C(0b11101010), C(0b10101010) };
-    constexpr char data[] = {
+    char data[] = {
         flags[1], flags[0],
         '\x12', '\x34',                                         // bodyFatPercentage
         '\xE7', '\x07', '\x02', '\x06', '\x12', '\x1C', '\x00', // timeStamp
@@ -270,7 +272,8 @@ TEST_F(BodyCompositionMeasurementTest, FeaturesOdd_SinglePacket_ReservedAll)
 
     EXPECT_EQ("BodyFatPercentage: 1333%, TimeStamp: 06.02.2023 18:28:00, BasalMetabolism: 17699kJ, MuscleMass: 132.185kg, SoftLeanMass: 175.875kg, Impedance: 4391.3Ω, Height: 52.651m", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    data[0] |= 1;  // Imperial
+    result = bleValueParser.make_value<BodyCompositionMeasurement>(data, sizeof(data));
     EXPECT_FLOAT_EQ(1333.0, result->bodyFatPercentage());
     EXPECT_EQ(2023, result->year());
     EXPECT_EQ(02, result->month());
@@ -295,7 +298,7 @@ TEST_F(BodyCompositionMeasurementTest, FeaturesEven_MultiplePacket_ReservedNone)
 {
     //                             RRRMFFFF       FFFFFFFU
     constexpr char flags[] = { C(0b00010101), C(0b01010100) };
-    constexpr char data[] = {
+    char data[] = {
         flags[1], flags[0],
         '\x12', '\x34',                                         // bodyFatPercentage
         '\x2A',                                                 // userID
@@ -362,7 +365,8 @@ TEST_F(BodyCompositionMeasurementTest, FeaturesEven_MultiplePacket_ReservedNone)
 
     EXPECT_EQ("BodyFatPercentage: 1333%, UserID: 42, MusclePercentage: 2206.8%, FatFreeMass: 154.03kg, BodyWaterMass: 197.72kg, Weight: 241.41kg", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    data[0] |= 1;  // Imperial
+    result = bleValueParser.make_value<BodyCompositionMeasurement>(data, sizeof(data));
     EXPECT_FLOAT_EQ(1333.0, result->bodyFatPercentage());
     EXPECT_EQ(0, result->year());
     EXPECT_EQ(0, result->month());
@@ -387,7 +391,7 @@ TEST_F(BodyCompositionMeasurementTest, MeasurementUnsuccessful)
 {
     //                             RRRMFFFF       FFFFFFFU
     constexpr char flags[] = { C(0b00000000), C(0b00000000) };
-    constexpr char data[] = {
+    char data[] = {
         flags[1], flags[0],
         '\xFF', '\xFF'                                          // bodyFatPercentage
     };
@@ -399,7 +403,8 @@ TEST_F(BodyCompositionMeasurementTest, MeasurementUnsuccessful)
 
     EXPECT_EQ("<MeasurementUnsuccessful>", result->toString());
 
-    result->configuration.measurementUnits = MeasurementUnitsEnum::Imperial;
+    data[0] |= 1;  // Imperial
+    result = bleValueParser.make_value<BodyCompositionMeasurement>(data, sizeof(data));
     EXPECT_EQ("<MeasurementUnsuccessful>", result->toString());
 }
 

--- a/tests/hexstringtest.cpp
+++ b/tests/hexstringtest.cpp
@@ -18,6 +18,7 @@ TEST_F(HexStringTest, Basic)
     auto result = bleValueParser.make_value<HexString>(data, sizeof(data));
     EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
+    EXPECT_EQ("\x01\x02\x03\x0D\x0E\x0F", result->rawString());
 
     EXPECT_EQ("0x 01:02:03:0D:0E:0F", result->toString());
 }
@@ -27,6 +28,7 @@ TEST_F(HexStringTest, Empty)
     auto result = bleValueParser.make_value<HexString>({}, 0);
     EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
+    EXPECT_EQ("", result->rawString());
 
     EXPECT_EQ("0x", result->toString());
 }


### PR DESCRIPTION
- changed: increased performance of BatteryLevelStatus (~19%), BodyCompositionMeasurementMIBFS (~11%), BodyCompositionMeasurement (~17%), CurrentTime (~44%), ExactTime256 (~37%) parsers
- changed: HexString output formating moved from parser to `toString()` function
- chagend: boilerplates of getters and parsers replaced with macroses
- changed: `isWideFormat()` and `hasRRIntervals()` of HeartRateMeasurement are moved to public