### PR TITLE
String optimization

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -24,6 +24,8 @@ jobs:
             ARCH: clang_64
             CLANG_TIDY: ''
         include:
+          - QT_VERSION: 5.15.2
+            QT_ARCH: '-DCMAKE_OSX_ARCHITECTURES=x86_64'  # Workaround for Qt 5.15.2 on Apple Silicon
           - QT_VERSION: 6.2.4
             QT_MODULES: qtconnectivity
 
@@ -61,7 +63,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -G Ninja -B ${{env.BUILD_DIR}}/gui -DBUILD_BENCHMARKS=OFF -DBUILD_TESTS=OFF -DBUILD_TUI_EXAMPLE=OFF -DCMAKE_BUILD_TYPE=${{matrix.BUILD_TYPE}} ${{matrix.RUNNER.CLANG_TIDY}}
+      run: cmake -G Ninja -B ${{env.BUILD_DIR}}/gui -DBUILD_BENCHMARKS=OFF -DBUILD_TESTS=OFF -DBUILD_TUI_EXAMPLE=OFF -DCMAKE_BUILD_TYPE=${{matrix.BUILD_TYPE}} ${{matrix.RUNNER.CLANG_TIDY}} ${{matrix.QT_ARCH}}
 
     - name: Build
       # Build your program with the given configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 include(GNUInstallDirs)
 
+find_package(fmt REQUIRED)
+
 set(LIBRARY_SOURCES
     include/blevalueparser/bvp.h
     # common
@@ -65,6 +67,9 @@ target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_14)
 target_include_directories(${PROJECT_NAME} INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+target_link_libraries(${PROJECT_NAME} INTERFACE
+    fmt::fmt
 )
 
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html

--- a/cmake/Findfmt.cmake
+++ b/cmake/Findfmt.cmake
@@ -1,0 +1,9 @@
+include(FetchContent)
+FetchContent_Declare(
+    fmt
+    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+    GIT_TAG        a33701196adfad74917046096bf5a2aa0ab0bb50 # release-9.1.0
+)
+FetchContent_MakeAvailable(fmt)
+
+set(fmt_FOUND 1)

--- a/examples/gui/CMakeLists.txt
+++ b/examples/gui/CMakeLists.txt
@@ -1,17 +1,24 @@
 cmake_minimum_required(VERSION 3.19)
 
-# vvv This part must be before project() vvv
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Bluetooth Core Quick QuickControls2 LinguistTools)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Bluetooth Core Quick QuickControls2 LinguistTools)
-
-if(APPLE AND (${QT_VERSION_MAJOR} LESS 6))
-    set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE INTERNAL "Workaround for Qt 5.15.2 on Apple Silicon" FORCE)
-endif()
-# ^^^ This part must be before project() ^^^
-
 project(bvpqt VERSION 0.1 DESCRIPTION "BLE Value Parser Library GUI Demo Application" LANGUAGES CXX)
 set(COMPANY_NAME eisaev)
 set(COMPANY_TLD dev)
+
+option(QT5_ARCH_ERROR "Fail for Qt 5.15.2 on Apple Silicon without forced architecture value" ON)
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Bluetooth Core Quick QuickControls2 LinguistTools)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Bluetooth Core Quick QuickControls2 LinguistTools)
+
+if(QT5_ARCH_ERROR AND APPLE AND (${QT_VERSION_MAJOR} LESS 6))
+    if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm64" AND NOT ("${CMAKE_OSX_ARCHITECTURES}" STREQUAL "x86_64"))
+        message(
+            FATAL_ERROR
+            "Prebuilt version of Qt 5.15.2 on Apple Silicon has x86_64 architecture. "
+            "Probably you will have to manually set CMAKE_OSX_ARCHITECTURE to 'x86_64' "
+            "to avoid linker errors."
+        )
+    endif()
+endif()
 
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)

--- a/examples/tui/demoapplication.cpp
+++ b/examples/tui/demoapplication.cpp
@@ -1,6 +1,7 @@
 #include "demoapplication.h"
 
 #include <iostream>
+#include <iomanip>
 #include <chrono>
 #include <thread>
 

--- a/include/blevalueparser/alertcategoryid.h
+++ b/include/blevalueparser/alertcategoryid.h
@@ -23,24 +23,31 @@ enum class AlertCategoryIDEnum : uint8_t
     Reserved                = 10,  // 10–250 - Reserved for Future Use
     DefinedByService        = 251  // 251–255 - Defined by Service Specification
 };
-inline std::ostream &operator<<(std::ostream &os, const AlertCategoryIDEnum value)
+inline std::string enumToString(const AlertCategoryIDEnum value)
 {
+    std::string str;
+
     switch (value)
     {
-        case AlertCategoryIDEnum::SimpleAlert:          os << "SimpleAlert";            break;
-        case AlertCategoryIDEnum::Email:                os << "Email";                  break;
-        case AlertCategoryIDEnum::News:                 os << "News";                   break;
-        case AlertCategoryIDEnum::Call:                 os << "Call";                   break;
-        case AlertCategoryIDEnum::MissedCall:           os << "MissedCall";             break;
-        case AlertCategoryIDEnum::SMSMMS:               os << "SMS/MMS";                break;
-        case AlertCategoryIDEnum::VoiceMail:            os << "VoiceMail";              break;
-        case AlertCategoryIDEnum::Schedule:             os << "Schedule";               break;
-        case AlertCategoryIDEnum::HighPrioritizedAlert: os << "HighPrioritizedAlert";   break;
-        case AlertCategoryIDEnum::InstantMessage:       os << "InstantMessage";         break;
-        case AlertCategoryIDEnum::Reserved:             os << "<Reserved>";             break;
-        case AlertCategoryIDEnum::DefinedByService:     os << "<DefinedByService>";     break;
+        case AlertCategoryIDEnum::SimpleAlert:          str = "SimpleAlert";            break;
+        case AlertCategoryIDEnum::Email:                str = "Email";                  break;
+        case AlertCategoryIDEnum::News:                 str = "News";                   break;
+        case AlertCategoryIDEnum::Call:                 str = "Call";                   break;
+        case AlertCategoryIDEnum::MissedCall:           str = "MissedCall";             break;
+        case AlertCategoryIDEnum::SMSMMS:               str = "SMS/MMS";                break;
+        case AlertCategoryIDEnum::VoiceMail:            str = "VoiceMail";              break;
+        case AlertCategoryIDEnum::Schedule:             str = "Schedule";               break;
+        case AlertCategoryIDEnum::HighPrioritizedAlert: str = "HighPrioritizedAlert";   break;
+        case AlertCategoryIDEnum::InstantMessage:       str = "InstantMessage";         break;
+        case AlertCategoryIDEnum::Reserved:             str = "<Reserved>";             break;
+        case AlertCategoryIDEnum::DefinedByService:     str = "<DefinedByService>";     break;
     }
 
+    return str;
+}
+inline std::ostream &operator<<(std::ostream &os, const AlertCategoryIDEnum value)
+{
+    os << enumToString(value);
     return os;
 }
 inline AlertCategoryIDEnum &operator%=(AlertCategoryIDEnum &lhs, const AlertCategoryIDEnum &rhs)
@@ -97,11 +104,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, AlertCategoryID, AlertCategoryIDStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 1;
-    }
-
     BVP_PARSE(AlertCategoryIDStruct)
     {
         bool result{true};
@@ -111,9 +113,14 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(AlertCategoryIDStruct)
     {
-        oss << m_btSpecObject.categoryID;
+        return enumToString(btSpecObject.categoryID);
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 1;
     }
 };
 

--- a/include/blevalueparser/alertcategoryidbitmask.h
+++ b/include/blevalueparser/alertcategoryidbitmask.h
@@ -91,11 +91,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, AlertCategoryIDBitMask, AlertCategoryIDBitMaskStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 2;
-    }
-
     BVP_PARSE(AlertCategoryIDBitMaskStruct)
     {
         bool result{true};
@@ -105,50 +100,69 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(AlertCategoryIDBitMaskStruct)
     {
-        oss << "{";
-        if (hasSimpleAlert())
+        std::string str;
+
+        str.append("{");
+        if (hasSimpleAlert(btSpecObject))
         {
-            oss << " " << AlertCategoryIDEnum::SimpleAlert;
+            str.append(" ");
+            str.append(enumToString(AlertCategoryIDEnum::SimpleAlert));
         }
-        if (hasEmail())
+        if (hasEmail(btSpecObject))
         {
-            oss << " " << AlertCategoryIDEnum::Email;
+            str.append(" ");
+            str.append(enumToString(AlertCategoryIDEnum::Email));
         }
-        if (hasNews())
+        if (hasNews(btSpecObject))
         {
-            oss << " " << AlertCategoryIDEnum::News;
+            str.append(" ");
+            str.append(enumToString(AlertCategoryIDEnum::News));
         }
-        if (hasCall())
+        if (hasCall(btSpecObject))
         {
-            oss << " " << AlertCategoryIDEnum::Call;
+            str.append(" ");
+            str.append(enumToString(AlertCategoryIDEnum::Call));
         }
-        if (hasMissedCall())
+        if (hasMissedCall(btSpecObject))
         {
-            oss << " " << AlertCategoryIDEnum::MissedCall;
+            str.append(" ");
+            str.append(enumToString(AlertCategoryIDEnum::MissedCall));
         }
-        if (hasSMSMMS())
+        if (hasSMSMMS(btSpecObject))
         {
-            oss << " " << AlertCategoryIDEnum::SMSMMS;
+            str.append(" ");
+            str.append(enumToString(AlertCategoryIDEnum::SMSMMS));
         }
-        if (hasVoiceMail())
+        if (hasVoiceMail(btSpecObject))
         {
-            oss << " " << AlertCategoryIDEnum::VoiceMail;
+            str.append(" ");
+            str.append(enumToString(AlertCategoryIDEnum::VoiceMail));
         }
-        if (hasSchedule())
+        if (hasSchedule(btSpecObject))
         {
-            oss << " " << AlertCategoryIDEnum::Schedule;
+            str.append(" ");
+            str.append(enumToString(AlertCategoryIDEnum::Schedule));
         }
-        if (hasHighPrioritizedAlert())
+        if (hasHighPrioritizedAlert(btSpecObject))
         {
-            oss << " " << AlertCategoryIDEnum::HighPrioritizedAlert;
+            str.append(" ");
+            str.append(enumToString(AlertCategoryIDEnum::HighPrioritizedAlert));
         }
-        if (hasInstantMessage())
+        if (hasInstantMessage(btSpecObject))
         {
-            oss << " " << AlertCategoryIDEnum::InstantMessage;
+            str.append(" ");
+            str.append(enumToString(AlertCategoryIDEnum::InstantMessage));
         }
-        oss << " }";
+        str.append(" }");
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 2;
     }
 };
 

--- a/include/blevalueparser/alertnotificationcontrolpoint.h
+++ b/include/blevalueparser/alertnotificationcontrolpoint.h
@@ -19,19 +19,26 @@ enum class AlertNotificationControlPointCommandIDEnum : uint8_t
     NotifyUnreadCategoryStatusImmediately   = 5,
     Reserved                                = 6  // 6–255 - Reserved for Future Use
 };
-inline std::ostream &operator<<(std::ostream &os, const AlertNotificationControlPointCommandIDEnum value)
+inline std::string enumToString(const AlertNotificationControlPointCommandIDEnum value)
 {
+    std::string str;
+
     switch (value)
     {
-        case AlertNotificationControlPointCommandIDEnum::EnableNewIncomingAlertNotification:        os << "EnableNewIncomingAlertNotification";         break;
-        case AlertNotificationControlPointCommandIDEnum::EnableUnreadCategoryStatusNotification:    os << "EnableUnreadCategoryStatusNotification";     break;
-        case AlertNotificationControlPointCommandIDEnum::DisableNewIncomingAlertNotification:       os << "DisableNewIncomingAlertNotification";        break;
-        case AlertNotificationControlPointCommandIDEnum::DisableUnreadCategoryStatusNotification:   os << "DisableUnreadCategoryStatusNotification";    break;
-        case AlertNotificationControlPointCommandIDEnum::NotifyNewIncomingAlertImmediately:         os << "NotifyNewIncomingAlertImmediately";          break;
-        case AlertNotificationControlPointCommandIDEnum::NotifyUnreadCategoryStatusImmediately:     os << "NotifyUnreadCategoryStatusImmediately";      break;
-        case AlertNotificationControlPointCommandIDEnum::Reserved:                                  os << "<Reserved>";                                 break;
+        case AlertNotificationControlPointCommandIDEnum::EnableNewIncomingAlertNotification:        str = "EnableNewIncomingAlertNotification";         break;
+        case AlertNotificationControlPointCommandIDEnum::EnableUnreadCategoryStatusNotification:    str = "EnableUnreadCategoryStatusNotification";     break;
+        case AlertNotificationControlPointCommandIDEnum::DisableNewIncomingAlertNotification:       str = "DisableNewIncomingAlertNotification";        break;
+        case AlertNotificationControlPointCommandIDEnum::DisableUnreadCategoryStatusNotification:   str = "DisableUnreadCategoryStatusNotification";    break;
+        case AlertNotificationControlPointCommandIDEnum::NotifyNewIncomingAlertImmediately:         str = "NotifyNewIncomingAlertImmediately";          break;
+        case AlertNotificationControlPointCommandIDEnum::NotifyUnreadCategoryStatusImmediately:     str = "NotifyUnreadCategoryStatusImmediately";      break;
+        case AlertNotificationControlPointCommandIDEnum::Reserved:                                  str = "<Reserved>";                                 break;
     }
 
+    return str;
+}
+inline std::ostream &operator<<(std::ostream &os, const AlertNotificationControlPointCommandIDEnum value)
+{
+    os << enumToString(value);
     return os;
 }
 inline AlertNotificationControlPointCommandIDEnum &operator%=(AlertNotificationControlPointCommandIDEnum &lhs, const AlertNotificationControlPointCommandIDEnum &rhs)
@@ -81,11 +88,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, AlertNotificationControlPoint, AlertNotificationControlPointStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 2;
-    }
-
     BVP_PARSE(AlertNotificationControlPointStruct)
     {
         bool result{true};
@@ -96,10 +98,22 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(AlertNotificationControlPointStruct)
     {
-        oss <<   "Command: " << m_btSpecObject.commandID;
-        oss << ", Category: " << m_btSpecObject.categoryID.categoryID;
+        std::string str;
+
+        str.append("Command: ");
+        str.append(enumToString(btSpecObject.commandID));
+
+        str.append(", Category: ");
+        str.append(enumToString(btSpecObject.categoryID.categoryID));
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 2;
     }
 };
 

--- a/include/blevalueparser/basevalue.h
+++ b/include/blevalueparser/basevalue.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <sstream>
 #include <map>
+#include <fmt/format.h>
+
 
 #define BVP_GETTER(TReturn, Name, TStruct)\
     TReturn Name() const\
@@ -43,6 +45,19 @@ TReturn Name() const\
         return parse(parser, m_btSpecObject);\
     }\
     static bool parse(Parser &parser, TStruct &btSpecObject)
+
+#define BVP_TO_STRING(TStruct)\
+    virtual std::string toStringInternal() const override\
+    {\
+        return toStringInternal(m_btSpecObject);\
+    }\
+    static std::string toStringInternal(const TStruct &btSpecObject)
+#define BVP_TO_STRING_CONF(TStruct)\
+    virtual std::string toStringInternal() const override\
+    {\
+        return toStringInternal(m_btSpecObject, configuration());\
+    }\
+    static std::string toStringInternal(const TStruct &btSpecObject, const Configuration &configuration)
 
 
 namespace bvp
@@ -117,9 +132,7 @@ public:
             }
         }
 
-        std::ostringstream oss;
-        oss << toFloat();
-        return oss.str();
+        return fmt::format("{:g}", toFloat());
     }
 
 private:
@@ -211,11 +224,13 @@ public:
             return "<Invalid>";
         }
 
-        std::ostringstream oss;
-        oss << configuration().stringPrefix;
-        toStringStream(oss);
-        oss << configuration().stringSuffix;
-        return oss.str();
+        std::string str;
+
+        str.append(configuration().stringPrefix);
+        str.append(toStringInternal());
+        str.append(configuration().stringSuffix);
+
+        return str;
     }
 
     virtual Configuration configuration() const
@@ -430,9 +445,9 @@ protected:
         create(parser);
     }
 
-    virtual bool checkSize(size_t size) = 0;
     virtual bool parse(Parser &parser) = 0;
-    virtual void toStringStream(std::ostringstream &oss) const = 0;
+    virtual std::string toStringInternal() const = 0;
+    virtual bool checkSize(size_t size) = 0;
 
     friend std::ostream &operator<<(std::ostream &os, const BaseValue &rhs)
     {

--- a/include/blevalueparser/batterycriticalstatus.h
+++ b/include/blevalueparser/batterycriticalstatus.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <iomanip>
-
 #include "basevalue.h"
 #include "batterylevel.h"
 
@@ -43,11 +41,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, BatteryCriticalStatus, BatteryCriticalStatusStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 1;
-    }
-
     BVP_PARSE(BatteryCriticalStatusStruct)
     {
         bool result{true};
@@ -57,18 +50,27 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(BatteryCriticalStatusStruct)
     {
-        oss << "{";
-        if (isCriticalPowerState())
+        std::string str;
+
+        str.append("{");
+        if (isCriticalPowerState(btSpecObject))
         {
-            oss << " CriticalPowerState";
+            str.append(" CriticalPowerState");
         }
-        if (isImmediateServiceRequired())
+        if (isImmediateServiceRequired(btSpecObject))
         {
-            oss << " ImmediateServiceRequired";
+            str.append(" ImmediateServiceRequired");
         }
-        oss << " }";
+        str.append(" }");
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 1;
     }
 };
 

--- a/include/blevalueparser/batteryenergystatus.h
+++ b/include/blevalueparser/batteryenergystatus.h
@@ -96,11 +96,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, BatteryEnergyStatus, BatteryEnergyStatusStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size > 0 && size < 14;
-    }
-
     BVP_PARSE(BatteryEnergyStatusStruct)
     {
         bool result{true};
@@ -135,43 +130,61 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(BatteryEnergyStatusStruct)
     {
-        std::ostringstream ossInfo;
-        if (isExternalSourcePowerPresent())
-        {
-            ossInfo << "ExternalSourcePower: " << m_btSpecObject.externalSourcePower << "W, ";
-        }
-        if (isPresentVoltagePresent())
-        {
-            ossInfo << "PresentVoltage: " << m_btSpecObject.presentVoltage << "V, ";
-        }
-        if (isAvailableEnergyPresent())
-        {
-            ossInfo << "AvailableEnergy: " << m_btSpecObject.availableEnergy << "kWh, ";
-        }
-        if (isAvailableBatteryCapacityPresent())
-        {
-            ossInfo << "AvailableBatteryCapacity: " << m_btSpecObject.availableBatteryCapacity << "kWh, ";
-        }
-        if (isChargeRatePresent())
-        {
-            ossInfo << "ChargeRate: " << m_btSpecObject.chargeRate << "W, ";
-        }
-        if (isAvailableEnergyAtLastChargePresent())
-        {
-            ossInfo << "AvailableEnergyAtLastCharge: " << m_btSpecObject.availableEnergyAtLastCharge << "kWh, ";
-        }
-        std::string info = ossInfo.str();
+        std::string str;
 
-        if (info.empty())
+        if (isExternalSourcePowerPresent(btSpecObject))
         {
-            oss << "<NoData>";
+            str.append("ExternalSourcePower: ");
+            str.append(btSpecObject.externalSourcePower.toString());
+            str.append("W, ");
         }
-        else
+        if (isPresentVoltagePresent(btSpecObject))
         {
-            oss << info.substr(0, info.length() - 2);
+            str.append("PresentVoltage: ");
+            str.append(btSpecObject.presentVoltage.toString());
+            str.append("V, ");
         }
+        if (isAvailableEnergyPresent(btSpecObject))
+        {
+            str.append("AvailableEnergy: ");
+            str.append(btSpecObject.availableEnergy.toString());
+            str.append("kWh, ");
+        }
+        if (isAvailableBatteryCapacityPresent(btSpecObject))
+        {
+            str.append("AvailableBatteryCapacity: ");
+            str.append(btSpecObject.availableBatteryCapacity.toString());
+            str.append("kWh, ");
+        }
+        if (isChargeRatePresent(btSpecObject))
+        {
+            str.append("ChargeRate: ");
+            str.append(btSpecObject.chargeRate.toString());
+            str.append("W, ");
+        }
+        if (isAvailableEnergyAtLastChargePresent(btSpecObject))
+        {
+            str.append("AvailableEnergyAtLastCharge: ");
+            str.append(btSpecObject.availableEnergyAtLastCharge.toString());
+            str.append("kWh, ");
+        }
+
+        if (str.empty())
+        {
+            return "<NoData>";
+        }
+
+        str.pop_back();
+        str.pop_back();
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size > 0 && size < 14;
     }
 };
 

--- a/include/blevalueparser/batteryinformation.h
+++ b/include/blevalueparser/batteryinformation.h
@@ -58,27 +58,34 @@ enum class BatteryChemistryEnum : uint8_t
     // 14–254 - Reserved for Future Use
     Other       = 255
 };
-inline std::ostream &operator<<(std::ostream &os, const BatteryChemistryEnum value)
+inline std::string enumToString(const BatteryChemistryEnum value)
 {
+    std::string str;
+
     switch (value)
     {
-        case BatteryChemistryEnum::Unknown:     os << "<Unknown>";  break;
-        case BatteryChemistryEnum::Alkaline:    os << "Alkaline";   break;
-        case BatteryChemistryEnum::LeadAcid:    os << "LeadAcid";   break;
-        case BatteryChemistryEnum::LiFeS2:      os << "LiFeS2";     break;
-        case BatteryChemistryEnum::LiMnO2:      os << "LiMnO2";     break;
-        case BatteryChemistryEnum::LiIon:       os << "LiIon";      break;
-        case BatteryChemistryEnum::LiPo:        os << "LiPo";       break;
-        case BatteryChemistryEnum::NiOx:        os << "NiOx";       break;
-        case BatteryChemistryEnum::NiCd:        os << "NiCd";       break;
-        case BatteryChemistryEnum::NiMH:        os << "NiMH";       break;
-        case BatteryChemistryEnum::AgZn:        os << "AgZn";       break;
-        case BatteryChemistryEnum::ZnChloride:  os << "ZnChloride"; break;
-        case BatteryChemistryEnum::ZnAir:       os << "ZnAir";      break;
-        case BatteryChemistryEnum::ZnCarbon:    os << "ZnCarbon";   break;
-        case BatteryChemistryEnum::Other:       os << "<Other>";    break;
+        case BatteryChemistryEnum::Unknown:     str = "<Unknown>";  break;
+        case BatteryChemistryEnum::Alkaline:    str = "Alkaline";   break;
+        case BatteryChemistryEnum::LeadAcid:    str = "LeadAcid";   break;
+        case BatteryChemistryEnum::LiFeS2:      str = "LiFeS2";     break;
+        case BatteryChemistryEnum::LiMnO2:      str = "LiMnO2";     break;
+        case BatteryChemistryEnum::LiIon:       str = "LiIon";      break;
+        case BatteryChemistryEnum::LiPo:        str = "LiPo";       break;
+        case BatteryChemistryEnum::NiOx:        str = "NiOx";       break;
+        case BatteryChemistryEnum::NiCd:        str = "NiCd";       break;
+        case BatteryChemistryEnum::NiMH:        str = "NiMH";       break;
+        case BatteryChemistryEnum::AgZn:        str = "AgZn";       break;
+        case BatteryChemistryEnum::ZnChloride:  str = "ZnChloride"; break;
+        case BatteryChemistryEnum::ZnAir:       str = "ZnAir";      break;
+        case BatteryChemistryEnum::ZnCarbon:    str = "ZnCarbon";   break;
+        case BatteryChemistryEnum::Other:       str = "<Other>";    break;
     }
 
+    return str;
+}
+inline std::ostream &operator<<(std::ostream &os, const BatteryChemistryEnum value)
+{
+    os << enumToString(value);
     return os;
 }
 inline BatteryChemistryEnum &operator%=(BatteryChemistryEnum &lhs, const BatteryChemistryEnum &rhs)
@@ -221,11 +228,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, BatteryInformation, BatteryInformationStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size > 2 && size < 20;
-    }
-
     BVP_PARSE(BatteryInformationStruct)
     {
         bool result{true};
@@ -269,62 +271,82 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(BatteryInformationStruct)
     {
-        oss <<   "BatteryReplaceable: " << (isBatteryReplaceable() ? "Yes" : "No");
-        oss << ", BatteryRechargeable: " << (isBatteryRechargeable() ? "Yes" : "No");
+        std::string str;
 
-        std::ostringstream ossInfo;
-        if (isBatteryManufactureDatePresent())
+        str.append("BatteryReplaceable: ");
+        str.append(isBatteryReplaceable(btSpecObject) ? "Yes" : "No");
+
+        str.append(", BatteryRechargeable: ");
+        str.append(isBatteryRechargeable(btSpecObject) ? "Yes" : "No");
+
+        if (isBatteryManufactureDatePresent(btSpecObject))
         {
-            ossInfo << ", BatteryManufactureDate: " << DateUTC(m_btSpecObject.batteryManufactureDate, configuration());
+            str.append(", BatteryManufactureDate: ");
+            str.append(DateUTC::toStringInternal(btSpecObject.batteryManufactureDate));
         }
-        if (isBatteryExpirationDatePresent())
+        if (isBatteryExpirationDatePresent(btSpecObject))
         {
-            ossInfo << ", BatteryExpirationDate: " << DateUTC(m_btSpecObject.batteryExpirationDate, configuration());
+            str.append(", BatteryExpirationDate: ");
+            str.append(DateUTC::toStringInternal(btSpecObject.batteryExpirationDate));
         }
-        if (isBatteryDesignedCapacityPresent())
+        if (isBatteryDesignedCapacityPresent(btSpecObject))
         {
-            ossInfo << ", BatteryDesignedCapacity: " << m_btSpecObject.batteryDesignedCapacity << "kWh";
+            str.append(", BatteryDesignedCapacity: ");
+            str.append(btSpecObject.batteryDesignedCapacity.toString());
+            str.append("kWh");
         }
-        if (isBatteryLowEnergyPresent())
+        if (isBatteryLowEnergyPresent(btSpecObject))
         {
-            ossInfo << ", BatteryLowEnergy: " << m_btSpecObject.batteryLowEnergy << "kWh";
+            str.append(", BatteryLowEnergy: ");
+            str.append(btSpecObject.batteryLowEnergy.toString());
+            str.append("kWh");
         }
-        if (isBatteryCriticalEnergyPresent())
+        if (isBatteryCriticalEnergyPresent(btSpecObject))
         {
-            ossInfo << ", BatteryCriticalEnergy: " << m_btSpecObject.batteryCriticalEnergy << "kWh";
+            str.append(", BatteryCriticalEnergy: ");
+            str.append(btSpecObject.batteryCriticalEnergy.toString());
+            str.append("kWh");
         }
-        if (isBatteryChemistryPresent())
+        if (isBatteryChemistryPresent(btSpecObject))
         {
-            ossInfo << ", BatteryChemistry: " << m_btSpecObject.batteryChemistry;
+            str.append(", BatteryChemistry: ");
+            str.append(enumToString(btSpecObject.batteryChemistry));
         }
-        if (isNominalVoltagePresent())
+        if (isNominalVoltagePresent(btSpecObject))
         {
-            ossInfo << ", NominalVoltage: " << m_btSpecObject.nominalVoltage << "V";
+            str.append(", NominalVoltage: ");
+            str.append(btSpecObject.nominalVoltage.toString());
+            str.append("V");
         }
-        if (isBatteryAggregationGroupPresent())
+        if (isBatteryAggregationGroupPresent(btSpecObject))
         {
-            ossInfo << ", BatteryAggregationGroup: ";
-            if (0 == m_btSpecObject.batteryAggregationGroup)
+            str.append(", BatteryAggregationGroup: ");
+            if (0 == btSpecObject.batteryAggregationGroup)
             {
-                ossInfo << "<NotInGroup>";
+                str.append("<NotInGroup>");
             }
-            else if (255 == m_btSpecObject.batteryAggregationGroup)
+            else if (255 == btSpecObject.batteryAggregationGroup)
             {
-                ossInfo << "<Reserved>";
+                str.append("<Reserved>");
             }
             else
             {
-                ossInfo << static_cast<int>(m_btSpecObject.batteryAggregationGroup);
+                fmt::format_to(
+                    std::back_inserter(str),
+                    "{}",
+                    btSpecObject.batteryAggregationGroup
+                );
             }
         }
-        std::string info = ossInfo.str();
 
-        if (!info.empty())
-        {
-            oss << info;
-        }
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size > 2 && size < 20;
     }
 };
 

--- a/include/blevalueparser/batterylevel.h
+++ b/include/blevalueparser/batterylevel.h
@@ -29,11 +29,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, BatteryLevel, BatteryLevelStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 1;
-    }
-
     BVP_PARSE(BatteryLevelStruct)
     {
         bool result{true};
@@ -47,9 +42,14 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(BatteryLevelStruct)
     {
-        oss << static_cast<int>(m_btSpecObject.batteryLevel) << "%";
+        return fmt::format("{}%", btSpecObject.batteryLevel);
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 1;
     }
 };
 

--- a/include/blevalueparser/batterylevelstatus.h
+++ b/include/blevalueparser/batterylevelstatus.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <iomanip>
-
 #include "basevalue.h"
 #include "batterylevel.h"
 
@@ -52,16 +50,23 @@ enum class ExternalPowerSourceConnectedEnum
     Unknown     = 2,
     Reserved    = 3
 };
-inline std::ostream &operator<<(std::ostream &os, const ExternalPowerSourceConnectedEnum value)
+inline std::string enumToString(const ExternalPowerSourceConnectedEnum value)
 {
+    std::string str;
+
     switch (value)
     {
-        case ExternalPowerSourceConnectedEnum::No:          os << "No";         break;
-        case ExternalPowerSourceConnectedEnum::Yes:         os << "Yes";        break;
-        case ExternalPowerSourceConnectedEnum::Unknown:     os << "<Unknown>";  break;
-        case ExternalPowerSourceConnectedEnum::Reserved:    os << "<Reserved>"; break;
+        case ExternalPowerSourceConnectedEnum::No:          str = "No";         break;
+        case ExternalPowerSourceConnectedEnum::Yes:         str = "Yes";        break;
+        case ExternalPowerSourceConnectedEnum::Unknown:     str = "<Unknown>";  break;
+        case ExternalPowerSourceConnectedEnum::Reserved:    str = "<Reserved>"; break;
     }
 
+    return str;
+}
+inline std::ostream &operator<<(std::ostream &os, const ExternalPowerSourceConnectedEnum value)
+{
+    os << enumToString(value);
     return os;
 }
 
@@ -72,16 +77,23 @@ enum class BatteryChargeStateEnum
     DischargingActive   = 2,
     DischargingInactive = 3
 };
-inline std::ostream &operator<<(std::ostream &os, const BatteryChargeStateEnum value)
+inline std::string enumToString(const BatteryChargeStateEnum value)
 {
+    std::string str;
+
     switch (value)
     {
-        case BatteryChargeStateEnum::Unknown:               os << "<Unknown>";              break;
-        case BatteryChargeStateEnum::Charging:              os << "Charging";               break;
-        case BatteryChargeStateEnum::DischargingActive:     os << "DischargingActive";      break;
-        case BatteryChargeStateEnum::DischargingInactive:   os << "DischargingInactive";    break;
+        case BatteryChargeStateEnum::Unknown:               str = "<Unknown>";              break;
+        case BatteryChargeStateEnum::Charging:              str = "Charging";               break;
+        case BatteryChargeStateEnum::DischargingActive:     str = "DischargingActive";      break;
+        case BatteryChargeStateEnum::DischargingInactive:   str = "DischargingInactive";    break;
     }
 
+    return str;
+}
+inline std::ostream &operator<<(std::ostream &os, const BatteryChargeStateEnum value)
+{
+    os << enumToString(value);
     return os;
 }
 
@@ -92,15 +104,22 @@ enum class BatteryChargeLevelEnum
     Low         = 2,
     Critical    = 3
 };
-inline std::ostream &operator<<(std::ostream &os, const BatteryChargeLevelEnum value)
+inline std::string enumToString(BatteryChargeLevelEnum value)
 {
+    std::string str;
+
     switch (value) {
-        case BatteryChargeLevelEnum::Unknown:   os << "<Unknown>";  break;
-        case BatteryChargeLevelEnum::Good:      os << "Good";       break;
-        case BatteryChargeLevelEnum::Low:       os << "Low";        break;
-        case BatteryChargeLevelEnum::Critical:  os << "Critical";   break;
+        case BatteryChargeLevelEnum::Unknown:   str = "<Unknown>";  break;
+        case BatteryChargeLevelEnum::Good:      str = "Good";       break;
+        case BatteryChargeLevelEnum::Low:       str = "Low";        break;
+        case BatteryChargeLevelEnum::Critical:  str = "Critical";   break;
     }
 
+    return str;
+}
+inline std::ostream &operator<<(std::ostream &os, const BatteryChargeLevelEnum value)
+{
+    os << enumToString(value);
     return os;
 }
 
@@ -115,19 +134,26 @@ enum class ChargingTypeEnum
     Reserved2               = 6,
     Reserved3               = 7
 };
-inline std::ostream &operator<<(std::ostream &os, const ChargingTypeEnum value)
+inline std::string enumToString(const ChargingTypeEnum value)
 {
+    std::string str;
+
     switch (value) {
-        case ChargingTypeEnum::UnknownOrNotCharging:    os << "UnknownOrNotCharging";   break;
-        case ChargingTypeEnum::ConstantCurrent:         os << "ConstantCurrent";        break;
-        case ChargingTypeEnum::ConstantVoltage:         os << "ConstantVoltage";        break;
-        case ChargingTypeEnum::Trickle:                 os << "Trickle";                break;
-        case ChargingTypeEnum::Float:                   os << "Float";                  break;
-        case ChargingTypeEnum::Reserved1:               os << "<Reserved1>";            break;
-        case ChargingTypeEnum::Reserved2:               os << "<Reserved2>";            break;
-        case ChargingTypeEnum::Reserved3:               os << "<Reserved3>";            break;
+        case ChargingTypeEnum::UnknownOrNotCharging:    str = "UnknownOrNotCharging";   break;
+        case ChargingTypeEnum::ConstantCurrent:         str = "ConstantCurrent";        break;
+        case ChargingTypeEnum::ConstantVoltage:         str = "ConstantVoltage";        break;
+        case ChargingTypeEnum::Trickle:                 str = "Trickle";                break;
+        case ChargingTypeEnum::Float:                   str = "Float";                  break;
+        case ChargingTypeEnum::Reserved1:               str = "<Reserved1>";            break;
+        case ChargingTypeEnum::Reserved2:               str = "<Reserved2>";            break;
+        case ChargingTypeEnum::Reserved3:               str = "<Reserved3>";            break;
     }
 
+    return str;
+}
+inline std::ostream &operator<<(std::ostream &os, const ChargingTypeEnum value)
+{
+    os << enumToString(value);
     return os;
 }
 
@@ -151,15 +177,22 @@ enum class ServiceRequiredEnum
     Unknown     = 2,
     Reserved    = 3
 };
-inline std::ostream &operator<<(std::ostream &os, const ServiceRequiredEnum value)
+inline std::string enumToString(const ServiceRequiredEnum value)
 {
+    std::string str;
+
     switch (value) {
-        case ServiceRequiredEnum::False:    os << "False";      break;
-        case ServiceRequiredEnum::True:     os << "True";       break;
-        case ServiceRequiredEnum::Unknown:  os << "<Unknown>";  break;
-        case ServiceRequiredEnum::Reserved: os << "<Reserved>"; break;
+        case ServiceRequiredEnum::False:    str = "False";      break;
+        case ServiceRequiredEnum::True:     str = "True";       break;
+        case ServiceRequiredEnum::Unknown:  str = "<Unknown>";  break;
+        case ServiceRequiredEnum::Reserved: str = "<Reserved>"; break;
     }
 
+    return str;
+}
+inline std::ostream &operator<<(std::ostream &os, const ServiceRequiredEnum value)
+{
+    os << enumToString(value);
     return os;
 }
 
@@ -302,11 +335,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, BatteryLevelStatus, BatteryLevelStatusStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size > 2 && size < 8;
-    }
-
     BVP_PARSE(BatteryLevelStatusStruct)
     {
         bool result{true};
@@ -332,57 +360,80 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(BatteryLevelStatusStruct)
     {
-        oss <<   "WiredExternalPowerSourceConnected: " << wiredExternalPowerSourceConnected();
-        oss << ", WirelessExternalPowerSourceConnected: " << wirelessExternalPowerSourceConnected();
-        oss << ", BatteryChargeState: " << batteryChargeState();
-        oss << ", BatteryChargeLevel: " << batteryChargeLevel();
-        oss << ", ChargingType: " << chargingType();
+        std::string str;
 
-        if (hasChargingFault())
+        str.append("WiredExternalPowerSourceConnected: ");
+        str.append(enumToString(wiredExternalPowerSourceConnected(btSpecObject)));
+
+        str.append(", WirelessExternalPowerSourceConnected: ");
+        str.append(enumToString(wirelessExternalPowerSourceConnected(btSpecObject)));
+
+        str.append(", BatteryChargeState: ");
+        str.append(enumToString(batteryChargeState(btSpecObject)));
+
+        str.append(", BatteryChargeLevel: ");
+        str.append(enumToString(batteryChargeLevel(btSpecObject)));
+
+        str.append(", ChargingType: ");
+        str.append(enumToString(chargingType(btSpecObject)));
+
+        if (hasChargingFault(btSpecObject))
         {
-            oss << ", ChargingFaultReason: {";
-            if (isChargingFaultReasonBattery())
+            str.append(", ChargingFaultReason: {");
+            if (isChargingFaultReasonBattery(btSpecObject))
             {
-                oss << " Battery";
+                str.append(" Battery");
             }
-            if (isChargingFaultReasonExternalPowerSource())
+            if (isChargingFaultReasonExternalPowerSource(btSpecObject))
             {
-                oss << " ExternalPowerSource";
+                str.append(" ExternalPowerSource");
             }
-            if (isChargingFaultReasonOther())
+            if (isChargingFaultReasonOther(btSpecObject))
             {
-                oss << " Other";
+                str.append(" Other");
             }
-            oss << " }";
+            str.append(" }");
         }
 
-        if (isIdentifierPresent())
+        if (isIdentifierPresent(btSpecObject))
         {
-            auto originalFlags = oss.flags();
-            oss << ", ID: 0x" << std::uppercase << std::setfill('0') << std::setw(4) << std::hex << m_btSpecObject.identifier;
-            oss.flags(originalFlags);
+            fmt::format_to(
+                std::back_inserter(str),
+                // TODO: try to replace by local implementation (see HexString)
+                ", ID: 0x{:04X}",
+                btSpecObject.identifier
+            );
         }
 
-        if (isBatteryLevelPresent())
+        if (isBatteryLevelPresent(btSpecObject))
         {
-            oss << ", BatteryLevel: " << BatteryLevel(m_btSpecObject.batteryLevel, configuration());
+            str.append(", BatteryLevel: ");
+            str.append(BatteryLevel::toStringInternal(btSpecObject.batteryLevel));
         }
 
-        if (isAdditionalStatusPresent())
+        if (isAdditionalStatusPresent(btSpecObject))
         {
-            oss << ", ServiceRequired: " << serviceRequired();
-            if (hasBatteryFault())
+            str.append(", ServiceRequired: ");
+            str.append(enumToString(serviceRequired(btSpecObject)));
+            if (hasBatteryFault(btSpecObject))
             {
-                oss << ", BatteryFailed";
+                str.append(", BatteryFailed");
             }
         }
 
-        if (isBatteryPresent())
+        if (isBatteryPresent(btSpecObject))
         {
-            oss << ", BatteryPresent";
+            str.append(", BatteryPresent");
         }
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size > 2 && size < 8;
     }
 };
 

--- a/include/blevalueparser/batterytimestatus.h
+++ b/include/blevalueparser/batterytimestatus.h
@@ -6,6 +6,13 @@
 namespace bvp
 {
 
+namespace
+{
+constexpr uint32_t BTS_UNKNOWN = 0xFFFFFF;
+constexpr uint32_t BTS_GREATER = 0xFFFFFE;
+constexpr uint32_t BTS_MAX = BTS_GREATER - 1;
+}
+
 // GATT_Specification_Supplement_v8.pdf
 // 3.29.1 Flags field
 constexpr uint8_t BTS_FLAG_TIME_UNTIL_DISCHARGED_ON_STANDBY_PRESENT = 1 << 0;
@@ -57,45 +64,36 @@ public:
 
     BVP_GETTER(bool, isTimeUntilDischargedUnknown, BatteryTimeStatusStruct)
     {
-        return s_unknown == btSpecObject.timeUntilDischarged;
+        return BTS_UNKNOWN == btSpecObject.timeUntilDischarged;
     }
 
     BVP_GETTER(bool, isTimeUntilDischargedOnStandbyUnknown, BatteryTimeStatusStruct)
     {
-        return s_unknown == btSpecObject.timeUntilDischargedOnStandby;
+        return BTS_UNKNOWN == btSpecObject.timeUntilDischargedOnStandby;
     }
 
     BVP_GETTER(bool, isTimeUntilRechargedUnknown, BatteryTimeStatusStruct)
     {
-        return s_unknown == btSpecObject.timeUntilRecharged;
+        return BTS_UNKNOWN == btSpecObject.timeUntilRecharged;
     }
 
     BVP_GETTER(bool, isTimeUntilDischargedGreater, BatteryTimeStatusStruct)
     {
-        return s_greater == btSpecObject.timeUntilDischarged;
+        return BTS_GREATER == btSpecObject.timeUntilDischarged;
     }
 
     BVP_GETTER(bool, isTimeUntilDischargedOnStandbyGreater, BatteryTimeStatusStruct)
     {
-        return s_greater == btSpecObject.timeUntilDischargedOnStandby;
+        return BTS_GREATER == btSpecObject.timeUntilDischargedOnStandby;
     }
 
     BVP_GETTER(bool, isTimeUntilRechargedGreater, BatteryTimeStatusStruct)
     {
-        return s_greater == btSpecObject.timeUntilRecharged;
+        return BTS_GREATER == btSpecObject.timeUntilRecharged;
     }
 
 private:
     BVP_CTORS(BaseValueSpec, BatteryTimeStatus, BatteryTimeStatusStruct)
-
-    static constexpr uint32_t s_unknown = 0xFFFFFF;
-    static constexpr uint32_t s_greater = 0xFFFFFE;
-    static constexpr uint32_t s_max = s_greater - 1;
-
-    virtual bool checkSize(size_t size) override
-    {
-        return size > 3 && size < 11;
-    }
 
     BVP_PARSE(BatteryTimeStatusStruct)
     {
@@ -116,54 +114,79 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(BatteryTimeStatusStruct)
     {
-        oss << "TimeUntilDischarged: ";
-        if (isTimeUntilDischargedUnknown())
+        std::string str;
+
+        str.append("TimeUntilDischarged: ");
+        if (isTimeUntilDischargedUnknown(btSpecObject))
         {
-            oss << "<Unknown>";
+            str.append("<Unknown>");
         }
-        else if (isTimeUntilDischargedGreater())
+        else if (isTimeUntilDischargedGreater(btSpecObject))
         {
-            oss << ">" << s_max << " minutes";
+            // TODO: it should be possible to format this at compile time because BTS_MAX is constexpr
+            fmt::format_to(std::back_inserter(str), ">{} minutes", BTS_MAX);
         }
         else
         {
-            oss << m_btSpecObject.timeUntilDischarged << " minutes";
+            fmt::format_to(
+                std::back_inserter(str),
+                "{} minutes",
+                btSpecObject.timeUntilDischarged
+            );
         }
 
-        if (isTimeUntilDischargedOnStandbyPresent())
+        if (isTimeUntilDischargedOnStandbyPresent(btSpecObject))
         {
-            oss << ", TimeUntilDischargedOnStandby: ";
-            if (isTimeUntilDischargedOnStandbyUnknown())
+            str.append(", TimeUntilDischargedOnStandby: ");
+            if (isTimeUntilDischargedOnStandbyUnknown(btSpecObject))
             {
-                oss << "<Unknown>";
+                str.append("<Unknown>");
             }
-            else if (isTimeUntilDischargedOnStandbyGreater())
+            else if (isTimeUntilDischargedOnStandbyGreater(btSpecObject))
             {
-                oss << ">" << s_max << " minutes";
+                // TODO: it should be possible to format this at compile time because BTS_MAX is constexpr
+                fmt::format_to(std::back_inserter(str), ">{} minutes", BTS_MAX);
             }
             else
             {
-                oss << m_btSpecObject.timeUntilDischargedOnStandby << " minutes";
+                fmt::format_to(
+                    std::back_inserter(str),
+                    "{} minutes",
+                    btSpecObject.timeUntilDischargedOnStandby
+                );
             }
         }
-        if (isTimeUntilRechargedPresent())
+
+        if (isTimeUntilRechargedPresent(btSpecObject))
         {
-            oss << ", TimeUntilRecharged: ";
-            if (isTimeUntilRechargedUnknown())
+            str.append(", TimeUntilRecharged: ");
+            if (isTimeUntilRechargedUnknown(btSpecObject))
             {
-                oss << "<Unknown>";
+                str.append("<Unknown>");
             }
-            else if (isTimeUntilRechargedGreater())
+            else if (isTimeUntilRechargedGreater(btSpecObject))
             {
-                oss << ">" << s_max << " minutes";
+                // TODO: it should be possible to format this at compile time because BTS_MAX is constexpr
+                fmt::format_to(std::back_inserter(str), ">{} minutes", BTS_MAX);
             }
             else
             {
-                oss << m_btSpecObject.timeUntilRecharged << " minutes";
+                fmt::format_to(
+                    std::back_inserter(str),
+                    "{} minutes",
+                    btSpecObject.timeUntilRecharged
+                );
             }
         }
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size > 3 && size < 11;
     }
 };
 

--- a/include/blevalueparser/bodycompositionfeature.h
+++ b/include/blevalueparser/bodycompositionfeature.h
@@ -194,11 +194,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, BodyCompositionFeature, BodyCompositionFeatureStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 4;
-    }
-
     BVP_PARSE(BodyCompositionFeatureStruct)
     {
         bool result{true};
@@ -208,33 +203,83 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING_CONF(BodyCompositionFeatureStruct)
     {
-        oss << "Features: {"
-           << (isTimeStampSupported() ?         " TimeStamp": "")
-           << (isMultipleUsersSupported() ?     " MultipleUsers": "")
-           << (isBasalMetabolismSupported() ?   " BasalMetabolism": "")
-           << (isMusclePercentageSupported() ?  " MusclePercentage": "")
-           << (isMuscleMassSupported() ?        " MuscleMass": "")
-           << (isFatFreeMassSupported() ?       " FatFreeMass": "")
-           << (isSoftLeanMassSupported() ?      " SoftLeanMass": "")
-           << (isBodyWaterMassSupported() ?     " BodyWaterMass": "")
-           << (isImpedanceSupported() ?         " Impedance": "")
-           << (isWeightSupported() ?            " Weight": "")
-           << (isHeightSupported() ?            " Height": "")
-           << " }";
+        std::string str;
 
-        if (isWeightSupported())
+        str.append("Features: {");
+        if (isTimeStampSupported(btSpecObject))
         {
-            oss << ", WeightResolution: " << weightResolution() / 1000.0
-                << configuration().massUnits();
+            str.append(" TimeStamp");
+        }
+        if (isMultipleUsersSupported(btSpecObject))
+        {
+            str.append(" MultipleUsers");
+        }
+        if (isBasalMetabolismSupported(btSpecObject))
+        {
+            str.append(" BasalMetabolism");
+        }
+        if (isMusclePercentageSupported(btSpecObject))
+        {
+            str.append(" MusclePercentage");
+        }
+        if (isMuscleMassSupported(btSpecObject))
+        {
+            str.append(" MuscleMass");
+        }
+        if (isFatFreeMassSupported(btSpecObject))
+        {
+            str.append(" FatFreeMass");
+        }
+        if (isSoftLeanMassSupported(btSpecObject))
+        {
+            str.append(" SoftLeanMass");
+        }
+        if (isBodyWaterMassSupported(btSpecObject))
+        {
+            str.append(" BodyWaterMass");
+        }
+        if (isImpedanceSupported(btSpecObject))
+        {
+            str.append(" Impedance");
+        }
+        if (isWeightSupported(btSpecObject))
+        {
+            str.append(" Weight");
+        }
+        if (isHeightSupported(btSpecObject))
+        {
+            str.append(" Height");
+        }
+        str.append(" }");
+
+        if (isWeightSupported(btSpecObject))
+        {
+            fmt::format_to(
+                std::back_inserter(str),
+                ", WeightResolution: {}{}",
+                weightResolution(btSpecObject, configuration) / 1000.0,
+                configuration.massUnits()
+            );
         }
 
-        if (isHeightSupported())
+        if (isHeightSupported(btSpecObject))
         {
-            oss << ", HeightResolution: " << heightResolution() / 1000.0
-                << configuration().lenghtUnits();
+            fmt::format_to(
+                std::back_inserter(str),
+                ", HeightResolution: {}{}",
+                heightResolution(btSpecObject, configuration) / 1000.0,
+                configuration.lenghtUnits()
+            );
         }
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 4;
     }
 };
 

--- a/include/blevalueparser/bodycompositionmeasurement.h
+++ b/include/blevalueparser/bodycompositionmeasurement.h
@@ -102,70 +102,121 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING_CONF(BodyCompositionMeasurementStruct)
     {
-        if (isMeasurementUnsuccessful())
+        std::string str;
+
+        if (isMeasurementUnsuccessful(btSpecObject))
         {
-            oss << "<MeasurementUnsuccessful>";
-            return;
+            return "<MeasurementUnsuccessful>";
         }
 
-        oss << "BodyFatPercentage: " << bodyFatPercentage() << "%";
+        fmt::format_to(
+            std::back_inserter(str),
+            "BodyFatPercentage: {:g}%",
+            bodyFatPercentage(btSpecObject)
+        );
 
-        if (isTimeStampPresent())
+        if (isTimeStampPresent(btSpecObject))
         {
-            oss << ", TimeStamp: " << DateTime(m_btSpecObject.timeStamp, configuration());
+            str.append(", TimeStamp: ");
+            str.append(DateTime::toStringInternal(btSpecObject.timeStamp));
         }
 
-        if (isUserIDPresent())
+        if (isUserIDPresent(btSpecObject))
         {
-            oss << ", UserID: " << UserIndex(m_btSpecObject.userID, configuration());
+            str.append(", UserID: ");
+            str.append(UserIndex::toStringInternal(btSpecObject.userID));
         }
 
-        if (isBasalMetabolismPresent())
+        if (isBasalMetabolismPresent(btSpecObject))
         {
-            oss << ", BasalMetabolism: " << basalMetabolism() << "kJ";
+            fmt::format_to(
+                std::back_inserter(str),
+                ", BasalMetabolism: {}kJ",
+                basalMetabolism(btSpecObject)
+            );
         }
 
-        if (isMusclePercentagePresent())
+        if (isMusclePercentagePresent(btSpecObject))
         {
-            oss << ", MusclePercentage: " << musclePercentage() << "%";
+            fmt::format_to(
+                std::back_inserter(str),
+                ", MusclePercentage: {:g}%",
+                musclePercentage(btSpecObject)
+            );
         }
 
-        if (isMuscleMassPresent())
+        if (isMuscleMassPresent(btSpecObject))
         {
-            oss << ", MuscleMass: " << muscleMass() << configuration().massUnits();
+            fmt::format_to(
+                std::back_inserter(str),
+                ", MuscleMass: {:g}{}",
+                muscleMass(btSpecObject, configuration),
+                configuration.massUnits()
+            );
         }
 
-        if (isFatFreeMassPresent())
+        if (isFatFreeMassPresent(btSpecObject))
         {
-            oss << ", FatFreeMass: " << fatFreeMass() << configuration().massUnits();
+            fmt::format_to(
+                std::back_inserter(str),
+                ", FatFreeMass: {:g}{}",
+                fatFreeMass(btSpecObject, configuration),
+                configuration.massUnits()
+            );
         }
 
-        if (isSoftLeanMassPresent())
+        if (isSoftLeanMassPresent(btSpecObject))
         {
-            oss << ", SoftLeanMass: " << softLeanMass() << configuration().massUnits();
+            fmt::format_to(
+                std::back_inserter(str),
+                ", SoftLeanMass: {:g}{}",
+                softLeanMass(btSpecObject, configuration),
+                configuration.massUnits()
+            );
         }
 
-        if (isBodyWaterMassPresent())
+        if (isBodyWaterMassPresent(btSpecObject))
         {
-            oss << ", BodyWaterMass: " << bodyWaterMass() << configuration().massUnits();
+            fmt::format_to(
+                std::back_inserter(str),
+                ", BodyWaterMass: {:g}{}",
+                bodyWaterMass(btSpecObject, configuration),
+                configuration.massUnits()
+            );
         }
 
-        if (isImpedancePresent())
+        if (isImpedancePresent(btSpecObject))
         {
-            oss << ", Impedance: " << impedance() << "Ω";
+            fmt::format_to(
+                std::back_inserter(str),
+                ", Impedance: {:g}Ω",
+                impedance(btSpecObject)
+            );
         }
 
-        if (isWeightPresent())
+        if (isWeightPresent(btSpecObject))
         {
-            oss << ", Weight: " << weight() << configuration().massUnits();
+            fmt::format_to(
+                std::back_inserter(str),
+                ", Weight: {:g}{}",
+                weight(btSpecObject, configuration),
+                configuration.massUnits()
+            );
         }
 
-        if (isHeightPresent())
+        if (isHeightPresent(btSpecObject))
         {
-            oss << ", Height: " << height() << configuration().lenghtUnits();
+            fmt::format_to(
+                std::back_inserter(str),
+                ", Height: {:g}{}",
+                height(btSpecObject, configuration),
+                configuration.lenghtUnits()
+            );
         }
+
+        return str;
     }
 };
 

--- a/include/blevalueparser/bodycompositionmeasurementmibfs.h
+++ b/include/blevalueparser/bodycompositionmeasurementmibfs.h
@@ -65,24 +65,49 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING_CONF(BodyCompositionMeasurementStruct)
     {
-        oss << (isUnloaded() ? "Unloaded" : isStabilized() ? "Stabilized" : "Unstable");
+        std::string str;
 
-        if (isTimeStampPresent())
+        if (isUnloaded(btSpecObject))
         {
-            oss << ", TimeStamp: " << DateTime(m_btSpecObject.timeStamp, configuration());
+            str.append("Unloaded");
+        }
+        else if (isStabilized(btSpecObject))
+        {
+            str.append("Stabilized");
+        }
+        else
+        {
+            str.append("Unstable");
         }
 
-        if (isImpedancePresent())
+        if (isTimeStampPresent(btSpecObject))
         {
-            oss << ", Impedance: " << impedance() << "Ω";
+            str.append(", TimeStamp: ");
+            str.append(DateTime::toStringInternal(btSpecObject.timeStamp));
         }
 
-        if (isWeightPresent())
+        if (isImpedancePresent(btSpecObject))
         {
-            oss << ", Weight: " << weight() << configuration().massUnits();
+            fmt::format_to(
+                std::back_inserter(str),
+                ", Impedance: {:g}Ω",
+                impedance(btSpecObject)
+            );
         }
+
+        if (isWeightPresent(btSpecObject))
+        {
+            fmt::format_to(
+                std::back_inserter(str),
+                ", Weight: {:g}{}",
+                weight(btSpecObject, configuration),
+                configuration.massUnits()
+            );
+        }
+
+        return str;
     }
 };
 

--- a/include/blevalueparser/bodysensorlocation.h
+++ b/include/blevalueparser/bodysensorlocation.h
@@ -19,20 +19,27 @@ enum class BodySensorLocationEnum
     EarLobe     = 5,
     Foot        = 6
 };
-inline std::ostream &operator<<(std::ostream &os, const BodySensorLocationEnum value)
+inline std::string enumToString(const BodySensorLocationEnum value)
 {
+    std::string str;
+
     switch (value)
     {
-        case BodySensorLocationEnum::Unknown: os << "<Unknown>";    break;
-        case BodySensorLocationEnum::Other:   os << "Other";        break;
-        case BodySensorLocationEnum::Chest:   os << "Chest";        break;
-        case BodySensorLocationEnum::Wrist:   os << "Wrist";        break;
-        case BodySensorLocationEnum::Finger:  os << "Finger";       break;
-        case BodySensorLocationEnum::Hand:    os << "Hand";         break;
-        case BodySensorLocationEnum::EarLobe: os << "Ear Lobe";     break;
-        case BodySensorLocationEnum::Foot:    os << "Foot";         break;
+        case BodySensorLocationEnum::Unknown: str = "<Unknown>";    break;
+        case BodySensorLocationEnum::Other:   str = "Other";        break;
+        case BodySensorLocationEnum::Chest:   str = "Chest";        break;
+        case BodySensorLocationEnum::Wrist:   str = "Wrist";        break;
+        case BodySensorLocationEnum::Finger:  str = "Finger";       break;
+        case BodySensorLocationEnum::Hand:    str = "Hand";         break;
+        case BodySensorLocationEnum::EarLobe: str = "Ear Lobe";     break;
+        case BodySensorLocationEnum::Foot:    str = "Foot";         break;
     }
 
+    return str;
+}
+inline std::ostream &operator<<(std::ostream &os, const BodySensorLocationEnum value)
+{
+    os << enumToString(value);
     return os;
 }
 inline BodySensorLocationEnum &operator%=(BodySensorLocationEnum &lhs, const BodySensorLocationEnum &rhs)
@@ -77,11 +84,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, BodySensorLocation, BodySensorLocationStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 1;
-    }
-
     BVP_PARSE(BodySensorLocationStruct)
     {
         bool result{true};
@@ -91,9 +93,14 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(BodySensorLocationStruct)
     {
-        oss << m_btSpecObject.bodySensorLocation;
+        return enumToString(btSpecObject.bodySensorLocation);
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 1;
     }
 };
 

--- a/include/blevalueparser/currenttime.h
+++ b/include/blevalueparser/currenttime.h
@@ -105,11 +105,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, CurrentTime, CurrentTimeStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 10;
-    }
-
     BVP_PARSE(CurrentTimeStruct)
     {
         bool result{true};
@@ -125,33 +120,43 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(CurrentTimeStruct)
     {
-        oss << ExactTime256(m_btSpecObject.exactTime256, configuration());
+        std::string str;
 
-        std::ostringstream ossAdjustReasons;
-        if (isManuallyAdjusted())
+        str.append(ExactTime256::toStringInternal(btSpecObject.exactTime256));
+
+        std::string adjustReason;
+        if (isManuallyAdjusted(btSpecObject))
         {
-            ossAdjustReasons << " ManuallyAdjusted";
+            adjustReason.append(" ManuallyAdjusted");
         }
-        if (isExternalReference())
+        if (isExternalReference(btSpecObject))
         {
-            ossAdjustReasons << " ExternalReference";
+            adjustReason.append(" ExternalReference");
         }
-        if (isTZChanged())
+        if (isTZChanged(btSpecObject))
         {
-            ossAdjustReasons << " TZChanged";
+            adjustReason.append(" TZChanged");
         }
-        if (isDSTChanged())
+        if (isDSTChanged(btSpecObject))
         {
-            ossAdjustReasons << " DSTChanged";
+            adjustReason.append(" DSTChanged");
         }
-        const std::string adjustReason = ossAdjustReasons.str();
 
         if (!adjustReason.empty())
         {
-            oss << " (adjust reason: {" << adjustReason << " })";
+            str.append(" (adjust reason: {");
+            str.append(adjustReason);
+            str.append(" })");
         }
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 10;
     }
 };
 

--- a/include/blevalueparser/datetime.h
+++ b/include/blevalueparser/datetime.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <iomanip>
-
 #include "basevalue.h"
 
 
@@ -63,11 +61,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, DateTime, DateTimeStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 7;
-    }
-
     BVP_PARSE(DateTimeStruct)
     {
         bool result{true};
@@ -82,14 +75,22 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(DateTimeStruct)
     {
-        oss <<        std::setfill('0') << std::setw(2) << static_cast<int>(day());
-        oss << "." << std::setfill('0') << std::setw(2) << static_cast<int>(month());
-        oss << "." << std::setfill('0') << std::setw(4) << static_cast<int>(year());
-        oss << " " << std::setfill('0') << std::setw(2) << static_cast<int>(hour());
-        oss << ":" << std::setfill('0') << std::setw(2) << static_cast<int>(minute());
-        oss << ":" << std::setfill('0') << std::setw(2) << static_cast<int>(seconds());
+        return fmt::format(
+            "{:02}.{:02}.{:04} {:02}:{:02}:{:02}",
+            day(btSpecObject),
+            month(btSpecObject),
+            year(btSpecObject),
+            hour(btSpecObject),
+            minute(btSpecObject),
+            seconds(btSpecObject)
+        );
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 7;
     }
 };
 

--- a/include/blevalueparser/dateutc.h
+++ b/include/blevalueparser/dateutc.h
@@ -1,9 +1,12 @@
 #pragma once
 
-#include <iomanip>
-
 #include "basevalue.h"
 
+
+namespace
+{
+static constexpr uint32_t secondsPerDay = 24 * 60 * 60;
+}
 
 namespace bvp
 {
@@ -56,13 +59,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, DateUTC, DateUTCStruct)
 
-    static constexpr uint32_t secondsPerDay = 24 * 60 * 60;
-
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 3;
-    }
-
     BVP_PARSE(DateUTCStruct)
     {
         bool result{true};
@@ -72,12 +68,20 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(DateUTCStruct)
     {
-        oss <<        std::setfill('0') << std::setw(2) << static_cast<int>(day());
-        oss << "." << std::setfill('0') << std::setw(2) << static_cast<int>(month());
-        oss << "." << std::setfill('0') << std::setw(4) << static_cast<int>(year());
-        oss << " (" << date() << " seconds since 1 Jan 1970)";
+        return fmt::format(
+            "{:02}.{:02}.{:04} ({} seconds since 1 Jan 1970)",
+            day(btSpecObject),
+            month(btSpecObject),
+            year(btSpecObject),
+            date(btSpecObject)
+        );
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 3;
     }
 };
 

--- a/include/blevalueparser/daydatetime.h
+++ b/include/blevalueparser/daydatetime.h
@@ -60,11 +60,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, DayDateTime, DayDateTimeStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 8;
-    }
-
     BVP_PARSE(DayDateTimeStruct)
     {
         bool result{true};
@@ -75,10 +70,20 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(DayDateTimeStruct)
     {
-        oss <<        DayOfWeek(m_btSpecObject.dayOfWeek, configuration());
-        oss << " " << DateTime(m_btSpecObject.dateTime, configuration());
+        std::string str;
+
+        str.append(DayOfWeek::toStringInternal(btSpecObject.dayOfWeek));
+        str.append(" ");
+        str.append(DateTime::toStringInternal(btSpecObject.dateTime));
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 8;
     }
 };
 

--- a/include/blevalueparser/dayofweek.h
+++ b/include/blevalueparser/dayofweek.h
@@ -21,20 +21,27 @@ enum class DayOfWeekEnum
     Sunday      = 7
     // 8–255 - Reserved for Future Use
 };
-inline std::ostream &operator<<(std::ostream &os, const DayOfWeekEnum value)
+inline std::string enumToString(const DayOfWeekEnum value)
 {
+    std::string str;
+
     switch (value)
     {
-        case DayOfWeekEnum::Unknown:    os << "<Unknown>";  break;
-        case DayOfWeekEnum::Monday:     os << "Mon";        break;
-        case DayOfWeekEnum::Tuesday:    os << "Tue";        break;
-        case DayOfWeekEnum::Wednesday:  os << "Wed";        break;
-        case DayOfWeekEnum::Thursday:   os << "Thu";        break;
-        case DayOfWeekEnum::Friday:     os << "Fri";        break;
-        case DayOfWeekEnum::Saturday:   os << "Sat";        break;
-        case DayOfWeekEnum::Sunday:     os << "Sun";        break;
+        case DayOfWeekEnum::Unknown:    str = "<Unknown>";  break;
+        case DayOfWeekEnum::Monday:     str = "Mon";        break;
+        case DayOfWeekEnum::Tuesday:    str = "Tue";        break;
+        case DayOfWeekEnum::Wednesday:  str = "Wed";        break;
+        case DayOfWeekEnum::Thursday:   str = "Thu";        break;
+        case DayOfWeekEnum::Friday:     str = "Fri";        break;
+        case DayOfWeekEnum::Saturday:   str = "Sat";        break;
+        case DayOfWeekEnum::Sunday:     str = "Sun";        break;
     }
 
+    return str;
+}
+inline std::ostream &operator<<(std::ostream &os, const DayOfWeekEnum value)
+{
+    os << enumToString(value);
     return os;
 }
 inline DayOfWeekEnum &operator%=(DayOfWeekEnum &lhs, const DayOfWeekEnum &rhs)
@@ -76,11 +83,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, DayOfWeek, DayOfWeekStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 1;
-    }
-
     BVP_PARSE(DayOfWeekStruct)
     {
         bool result{true};
@@ -90,9 +92,14 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(DayOfWeekStruct)
     {
-        oss << m_btSpecObject.dayOfWeek;
+        return enumToString(btSpecObject.dayOfWeek);
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 1;
     }
 };
 

--- a/include/blevalueparser/dstoffset.h
+++ b/include/blevalueparser/dstoffset.h
@@ -17,17 +17,24 @@ enum class DSTOffsetEnum
     DoubleDaylightTime2h        = 8,
     Unknown                     = 255
 };
-inline std::ostream &operator<<(std::ostream &os, const DSTOffsetEnum value)
+inline std::string enumToString(const DSTOffsetEnum value)
 {
+    std::string str;
+
     switch (value)
     {
-        case DSTOffsetEnum::StandardTime:               os << "Standard Time";                      break;
-        case DSTOffsetEnum::HalfAnHourDaylightTime0_5h: os << "Half an Hour Daylight Time (+0.5h)"; break;
-        case DSTOffsetEnum::DaylightTime1h:             os << "Daylight Time (+1h)";                break;
-        case DSTOffsetEnum::DoubleDaylightTime2h:       os << "Double Daylight Time (+2h)";         break;
-        case DSTOffsetEnum::Unknown:                    os << "<Unknown>";                          break;
+        case DSTOffsetEnum::StandardTime:               str = "Standard Time";                      break;
+        case DSTOffsetEnum::HalfAnHourDaylightTime0_5h: str = "Half an Hour Daylight Time (+0.5h)"; break;
+        case DSTOffsetEnum::DaylightTime1h:             str = "Daylight Time (+1h)";                break;
+        case DSTOffsetEnum::DoubleDaylightTime2h:       str = "Double Daylight Time (+2h)";         break;
+        case DSTOffsetEnum::Unknown:                    str = "<Unknown>";                          break;
     }
 
+    return str;
+}
+inline std::ostream &operator<<(std::ostream &os, const DSTOffsetEnum value)
+{
+    os << enumToString(value);
     return os;
 }
 inline DSTOffsetEnum &operator%=(DSTOffsetEnum &lhs, const DSTOffsetEnum &rhs)
@@ -67,11 +74,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, DSTOffset, DSTOffsetStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 1;
-    }
-
     BVP_PARSE(DSTOffsetStruct)
     {
         bool result{true};
@@ -81,9 +83,14 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(DSTOffsetStruct)
     {
-        oss << m_btSpecObject.dstOffset;
+        return enumToString(btSpecObject.dstOffset);
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 1;
     }
 };
 

--- a/include/blevalueparser/estimatedservicedate.h
+++ b/include/blevalueparser/estimatedservicedate.h
@@ -46,11 +46,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, EstimatedServiceDate, EstimatedServiceDateStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 3;
-    }
-
     BVP_PARSE(EstimatedServiceDateStruct)
     {
         bool result{true};
@@ -60,9 +55,14 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(EstimatedServiceDateStruct)
     {
-        oss << DateUTC(m_btSpecObject.estimatedServiceDate, configuration());
+        return DateUTC::toStringInternal(btSpecObject.estimatedServiceDate);
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 3;
     }
 };
 

--- a/include/blevalueparser/exacttime256.h
+++ b/include/blevalueparser/exacttime256.h
@@ -69,11 +69,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, ExactTime256, ExactTime256Struct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 9;
-    }
-
     BVP_PARSE(ExactTime256Struct)
     {
         bool result{true};
@@ -84,10 +79,18 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(ExactTime256Struct)
     {
-        oss <<        DayDateTime(m_btSpecObject.dayDateTime, configuration());
-        oss << "." << std::setfill('0') << std::setw(3) << static_cast<int>(milliseconds());
+        return fmt::format(
+            "{}.{:03}",
+            DayDateTime::toStringInternal(btSpecObject.dayDateTime),
+            milliseconds(btSpecObject)
+        );
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 9;
     }
 };
 

--- a/include/blevalueparser/heartratecontrolpoint.h
+++ b/include/blevalueparser/heartratecontrolpoint.h
@@ -13,14 +13,21 @@ enum class HeartRateControlPointEnum : uint8_t
     Reserved            = 0,  // 0, 2–255 - Reserved for Future Use
     ResetEnergyExpended = 1
 };
-inline std::ostream &operator<<(std::ostream &os, const HeartRateControlPointEnum value)
+inline std::string enumToString(const HeartRateControlPointEnum value)
 {
+    std::string str;
+
     switch (value)
     {
-        case HeartRateControlPointEnum::Reserved:               os << "<Reserved>";             break;
-        case HeartRateControlPointEnum::ResetEnergyExpended:    os << "ResetEnergyExpended";    break;
+        case HeartRateControlPointEnum::Reserved:               str = "<Reserved>";             break;
+        case HeartRateControlPointEnum::ResetEnergyExpended:    str = "ResetEnergyExpended";    break;
     }
 
+    return str;
+}
+inline std::ostream &operator<<(std::ostream &os, const HeartRateControlPointEnum value)
+{
+    os << enumToString(value);
     return os;
 }
 inline HeartRateControlPointEnum &operator%=(HeartRateControlPointEnum &lhs, const HeartRateControlPointEnum &rhs)
@@ -59,11 +66,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, HeartRateControlPoint, HeartRateControlPointStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 1;
-    }
-
     BVP_PARSE(HeartRateControlPointStruct)
     {
         bool result{true};
@@ -73,9 +75,14 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(HeartRateControlPointStruct)
     {
-        oss << m_btSpecObject.heartRateControlPoint;
+        return enumToString(btSpecObject.heartRateControlPoint);
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 1;
     }
 };
 

--- a/include/blevalueparser/heartratemeasurement.h
+++ b/include/blevalueparser/heartratemeasurement.h
@@ -87,12 +87,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, HeartRateMeasurement, HeartRateMeasurementStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        // Minimal packet must contain flags(uint8_t)+heartRate(uint8_t)
-        return size > 1 && size < 21;
-    }
-
     BVP_PARSE(HeartRateMeasurementStruct)
     {
         bool result{true};
@@ -139,36 +133,58 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(HeartRateMeasurementStruct)
     {
-        if (isContactSupported())
+        std::string str;
+
+        if (isContactSupported(btSpecObject))
         {
-            if (isContacted())
+            if (isContacted(btSpecObject))
             {
-                oss << "(connected) ";
+                str.append("(connected) ");
             }
             else
             {
-                oss << "(disconnected) ";
+                str.append("(disconnected) ");
             }
         }
 
-        oss << "HR: " << m_btSpecObject.heartRate << "bpm";
+        fmt::format_to(
+            std::back_inserter(str),
+            "HR: {}bpm",
+            btSpecObject.heartRate
+        );
 
-        if (hasEnergyExpended())
+        if (hasEnergyExpended(btSpecObject))
         {
-            oss << ", EE: " << m_btSpecObject.energyExpended << "kJ";
+            fmt::format_to(
+                std::back_inserter(str),
+                ", EE: {}kJ",
+                btSpecObject.energyExpended
+            );
         }
 
-        if (!m_btSpecObject.rrIntervals.empty())
+        if (!btSpecObject.rrIntervals.empty())
         {
-            oss << ", RR: { ";
-            for (auto rrInterval : rrIntervals())
+            str.append(", RR: { ");
+            for (auto rrInterval : rrIntervals(btSpecObject))
             {
-                oss << rrInterval << "ms; ";
+                fmt::format_to(
+                    std::back_inserter(str),
+                    "{}ms; ",
+                    rrInterval
+                );
             }
-            oss << "}";
+            str.append("}");
         }
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        // Minimal packet must contain flags(uint8_t)+heartRate(uint8_t)
+        return size > 1 && size < 21;
     }
 };
 

--- a/include/blevalueparser/hexstring.h
+++ b/include/blevalueparser/hexstring.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <iomanip>
-
 #include "basevalue.h"
 
 
@@ -24,12 +22,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, HexString, HexStringStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        (void)size;
-        return true;
-    }
-
     BVP_PARSE(HexStringStruct)
     {
         bool result{true};
@@ -39,73 +31,70 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING_CONF(HexStringStruct)
     {
-        const std::string separator{configuration().hexSeparator};
+        std::string str;
 
-// Stringstreams is too slooooOOO00OOOoooow!
-#if 0
-        // C++ way using stringstreams
-        // x1: ~277ns, x8: ~990ns, x64: ~5747ns, x512: ~42328ns
-        std::ostringstream ossTmp;
-        ossTmp << configuration().hexPrefix;
-        for (auto c : m_btSpecObject.rawString)
-        {
-            ossTmp << std::uppercase
-                   << std::setfill('0')
-                   << std::setw(2)
-                   << std::hex
-                   << static_cast<int>(c)
-                   << separator;
-        }
-        std::string hexString = ossTmp.str();
-#else
-        std::string hexString{configuration().hexPrefix};
+        const std::string separator{configuration.hexSeparator};
+
+        str.append(configuration.hexPrefix);
 
         constexpr std::array<char, 16> hexChars{
             '0', '1', '2', '3', '4', '5', '6', '7',
             '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
         };
 
-        const size_t rawStringSize{m_btSpecObject.rawString.size()};
+        const size_t rawStringSize{btSpecObject.rawString.size()};
         const size_t separatorSize{separator.size()};
-        const size_t size{configuration().hexPrefix.size() + rawStringSize * (2 + separatorSize)};
+        const size_t size{configuration.hexPrefix.size() + rawStringSize * (2 + separatorSize)};
 
 #if 0
         // Easy to read version without stringstreams
-        // x1: ~145ns (x1.9), x8: ~303ns (x3.3), x64: ~967ns (x5.9), x512: ~5283ns (x8)
-        hexString.reserve(size);
+        // String<HexString>/1         47.5 ns         47.5 ns     10804804
+        // String<HexString>/8          151 ns          151 ns      4681147
+        // String<HexString>/64         566 ns          566 ns      1232047
+        // String<HexString>/512       4058 ns         4057 ns       172167
+        str.reserve(size);
 
-        for (auto c : m_btSpecObject.rawString)
+        for (auto c : btSpecObject.rawString)
         {
-            hexString.push_back(hexChars[(c & 0xF0) >> 4]);
-            hexString.push_back(hexChars[c & 0x0F]);
-            hexString.append(separator);
+            str.push_back(hexChars[(c & 0xF0) >> 4]);
+            str.push_back(hexChars[c & 0x0F]);
+            str.append(separator);
         }
 #else
         // Hacky version (next one is plain C or Assembler?)
-        // x1: ~146ns (x1.9), x8: ~253ns (x3.9), x64: ~554ns (x10.4), x512: ~1970ns (x21.5)
-        hexString.resize(size);
+        // String<HexString>/1         46.0 ns         46.0 ns     11073146
+        // String<HexString>/8         98.1 ns         98.1 ns      7154611 (x1.54)
+        // String<HexString>/64         191 ns          191 ns      3658046 (x2.96)
+        // String<HexString>/512        965 ns          964 ns       728044 (x4.2)
+        str.resize(size);
 
-        size_t o{configuration().hexPrefix.size()};
+        size_t o{configuration.hexPrefix.size()};
         for (size_t i{0}; i < rawStringSize; ++i)
         {
-            const char c{m_btSpecObject.rawString[i]};
-            hexString[o] = hexChars[(c & 0xF0) >> 4];
+            const char c{btSpecObject.rawString[i]};
+            str[o] = hexChars[(c & 0xF0) >> 4];
             ++o;
-            hexString[o] = hexChars[c & 0x0F];
+            str[o] = hexChars[c & 0x0F];
             ++o;
             for (size_t s{0}; s < separatorSize; ++s)
             {
-                hexString[o] = separator[s];
+                str[o] = separator[s];
                 ++o;
             }
         }
 #endif
-#endif
-        hexString.pop_back();
 
-        oss << hexString;
+        str.pop_back();
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        (void)size;
+        return true;
     }
 };
 

--- a/include/blevalueparser/localtimeinformation.h
+++ b/include/blevalueparser/localtimeinformation.h
@@ -35,11 +35,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, LocalTimeInformation, LocalTimeInformationStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 2;
-    }
-
     BVP_PARSE(LocalTimeInformationStruct)
     {
         bool result{true};
@@ -50,10 +45,22 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(LocalTimeInformationStruct)
     {
-        oss <<   "TZ: "  << TimeZone(m_btSpecObject.timeZone, configuration());
-        oss << ", DST: " << DSTOffset(m_btSpecObject.dstOffset, configuration());
+        std::string str;
+
+        str.append("TZ: ");
+        str.append(TimeZone::toStringInternal(btSpecObject.timeZone));
+
+        str.append(", DST: ");
+        str.append(DSTOffset::toStringInternal(btSpecObject.dstOffset));
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 2;
     }
 };
 

--- a/include/blevalueparser/newalert.h
+++ b/include/blevalueparser/newalert.h
@@ -40,11 +40,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, NewAlert, NewAlertStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size > 1 && size < 21;
-    }
-
     BVP_PARSE(NewAlertStruct)
     {
         bool result{true};
@@ -56,11 +51,29 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(NewAlertStruct)
     {
-        oss <<   "Category: " << m_btSpecObject.categoryID.categoryID;
-        oss << ", NumberOfNewAlert: " << static_cast<int>(m_btSpecObject.numberOfNewAlert);
-        oss << ", RecentAlertBrief: '" << m_btSpecObject.textStringInformation << "'";
+        std::string str;
+
+        str.append("Category: ");
+        str.append(enumToString(btSpecObject.categoryID.categoryID));
+
+        fmt::format_to(
+            std::back_inserter(str),
+            ", NumberOfNewAlert: {}",
+            btSpecObject.numberOfNewAlert
+        );
+
+        str.append(", RecentAlertBrief: '");
+        str.append(btSpecObject.textStringInformation);
+        str.append("'");
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size > 1 && size < 21;
     }
 };
 

--- a/include/blevalueparser/supportedalertcategorybase.h
+++ b/include/blevalueparser/supportedalertcategorybase.h
@@ -83,11 +83,6 @@ protected:
         BaseValueSpec{btSpecObject, configuration}
     {}
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 2;
-    }
-
     BVP_PARSE(SupportedAlertCategoryBaseStruct)
     {
         bool result{true};
@@ -97,9 +92,19 @@ protected:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(SupportedAlertCategoryBaseStruct)
     {
-        oss << "SupportedCategories: " << AlertCategoryIDBitMask(m_btSpecObject.categoryIDBitMask, configuration());
+        std::string str;
+
+        str.append("SupportedCategories: ");
+        str.append(AlertCategoryIDBitMask::toStringInternal(btSpecObject.categoryIDBitMask));
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 2;
     }
 };
 

--- a/include/blevalueparser/textstring.h
+++ b/include/blevalueparser/textstring.h
@@ -22,12 +22,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, TextString, TextStringStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        (void)size;
-        return true;
-    }
-
     BVP_PARSE(TextStringStruct)
     {
         bool result{true};
@@ -37,9 +31,15 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(TextStringStruct)
     {
-        oss << m_btSpecObject.textString;
+        return btSpecObject.textString;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        (void)size;
+        return true;
     }
 };
 

--- a/include/blevalueparser/timeaccuracy.h
+++ b/include/blevalueparser/timeaccuracy.h
@@ -6,6 +6,11 @@
 namespace bvp
 {
 
+constexpr uint8_t TMA_LARGER = 254;
+constexpr uint8_t TMA_UNKNOWN = 255;
+constexpr uint8_t TMA_MULTIPLIER = 125;
+constexpr uint32_t TMA_MAX = (TMA_LARGER - 1) * TMA_MULTIPLIER;
+
 // GATT_Specification_Supplement_v8.pdf
 // 3.220 Time Accuracy
 
@@ -22,37 +27,29 @@ public:
     BVP_GETTER(bool, isLarger, TimeAccuracyStruct)
     {
         // A value of 254 means drift is larger than 31.625s.
-        return btSpecObject.accuracy == s_timeAccuracyLarge;
+        return btSpecObject.accuracy == TMA_LARGER;
     }
 
     BVP_GETTER(bool, isUnknown, TimeAccuracyStruct)
     {
         // A value of 255 means drift is unknown.
-        return btSpecObject.accuracy == s_timeAccuracyUnknown;
+        return btSpecObject.accuracy == TMA_UNKNOWN;
     }
 
     BVP_GETTER(uint16_t, accuracyMs, TimeAccuracyStruct)
     {
-        if (btSpecObject.accuracy >= s_timeAccuracyLarge)
+        if (btSpecObject.accuracy >= TMA_LARGER)
         {
             return UINT16_MAX;
         }
 
         // This field represents accuracy (drift) of time information
         // in steps of 1/8 of a second (125ms) compared to a reference time source.
-        return btSpecObject.accuracy * 125;
+        return btSpecObject.accuracy * TMA_MULTIPLIER;
     }
 
 private:
     BVP_CTORS(BaseValueSpec, TimeAccuracy, TimeAccuracyStruct)
-
-    static constexpr uint8_t s_timeAccuracyLarge   = 254;
-    static constexpr uint8_t s_timeAccuracyUnknown = 255;
-
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 1;
-    }
 
     BVP_PARSE(TimeAccuracyStruct)
     {
@@ -63,21 +60,25 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(TimeAccuracyStruct)
     {
-        if (isUnknown())
+        if (isUnknown(btSpecObject))
         {
-            oss << "<Unknown>";
-            return;
+            return "<Unknown>";
         }
 
-        if (isLarger())
+        if (isLarger(btSpecObject))
         {
-            oss << ">31625ms";
-            return;
+            // TODO: it should be possible to format this at compile time because TMA_MAX is constexpr
+            return fmt::format(">{}ms", TMA_MAX);
         }
 
-        oss << accuracyMs() << "ms";
+        return fmt::format("{}ms", accuracyMs(btSpecObject));
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 1;
     }
 };
 

--- a/include/blevalueparser/timesource.h
+++ b/include/blevalueparser/timesource.h
@@ -19,19 +19,26 @@ enum class TimeSourceEnum : uint8_t
     AtomicClock         = 5,
     CellularNetwork     = 6,
 };
-inline std::ostream &operator<<(std::ostream &os, const TimeSourceEnum value)
+inline std::string enumToString(const TimeSourceEnum value)
 {
+    std::string str;
+
     switch (value)
     {
-        case TimeSourceEnum::Unknown:               os << "<Unknown>";              break;
-        case TimeSourceEnum::NetworkTimeProtocol:   os << "NetworkTimeProtocol";    break;
-        case TimeSourceEnum::GPS:                   os << "GPS";                    break;
-        case TimeSourceEnum::RadioTimeSignal:       os << "RadioTimeSignal";        break;
-        case TimeSourceEnum::Manual:                os << "Manual";                 break;
-        case TimeSourceEnum::AtomicClock:           os << "AtomicClock";            break;
-        case TimeSourceEnum::CellularNetwork:       os << "CellularNetwork";        break;
+        case TimeSourceEnum::Unknown:               str = "<Unknown>";              break;
+        case TimeSourceEnum::NetworkTimeProtocol:   str = "NetworkTimeProtocol";    break;
+        case TimeSourceEnum::GPS:                   str = "GPS";                    break;
+        case TimeSourceEnum::RadioTimeSignal:       str = "RadioTimeSignal";        break;
+        case TimeSourceEnum::Manual:                str = "Manual";                 break;
+        case TimeSourceEnum::AtomicClock:           str = "AtomicClock";            break;
+        case TimeSourceEnum::CellularNetwork:       str = "CellularNetwork";        break;
     }
 
+    return str;
+}
+inline std::ostream &operator<<(std::ostream &os, const TimeSourceEnum value)
+{
+    os << enumToString(value);
     return os;
 }
 inline TimeSourceEnum &operator%=(TimeSourceEnum &lhs, const TimeSourceEnum &rhs)
@@ -72,11 +79,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, TimeSource, TimeSourceStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 1;
-    }
-
     BVP_PARSE(TimeSourceStruct)
     {
         bool result{true};
@@ -86,9 +88,14 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(TimeSourceStruct)
     {
-        oss << m_btSpecObject.timeSource;
+        return enumToString(btSpecObject.timeSource);
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 1;
     }
 };
 

--- a/include/blevalueparser/timezone.h
+++ b/include/blevalueparser/timezone.h
@@ -118,9 +118,18 @@ enum class TimeZoneEnum
     Plus55 = 55,
     Plus56 = 56
 };
+inline std::string enumToString(const TimeZoneEnum value)
+{
+    if (TimeZoneEnum::Unknown == value)
+    {
+        return "<Unknown>";
+    }
+
+    return fmt::format("{}", static_cast<int>(value));
+}
 inline std::ostream &operator<<(std::ostream &os, const TimeZoneEnum value)
 {
-    TimeZoneEnum::Unknown == value ? os << "<Unknown>" : os << static_cast<int>(value);
+    os << enumToString(value);
     return os;
 }
 inline TimeZoneEnum &operator%=(TimeZoneEnum &lhs, const TimeZoneEnum &rhs)
@@ -260,11 +269,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, TimeZone, TimeZoneStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 1;
-    }
-
     BVP_PARSE(TimeZoneStruct)
     {
         bool result{true};
@@ -274,9 +278,14 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(TimeZoneStruct)
     {
-        oss << m_btSpecObject.timeZone;
+        return enumToString(btSpecObject.timeZone);
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 1;
     }
 };
 

--- a/include/blevalueparser/unreadalertstatus.h
+++ b/include/blevalueparser/unreadalertstatus.h
@@ -7,6 +7,9 @@
 namespace bvp
 {
 
+constexpr uint8_t UAS_GREATER = 255;
+constexpr uint8_t UAS_MAX = UAS_GREATER - 1;
+
 // GATT_Specification_Supplement_v8.pdf
 // 3.238 Unread Alert Status
 struct UnreadAlertStatusStruct
@@ -33,19 +36,11 @@ public:
 
     BVP_GETTER(bool, isUnreadCountGreater, UnreadAlertStatusStruct)
     {
-        return s_greater == btSpecObject.unreadCount;
+        return UAS_GREATER == btSpecObject.unreadCount;
     }
 
 private:
     BVP_CTORS(BaseValueSpec, UnreadAlertStatus, UnreadAlertStatusStruct)
-
-    static constexpr uint8_t s_greater = 255;
-    static constexpr uint8_t s_max = s_greater - 1;
-
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 2;
-    }
 
     BVP_PARSE(UnreadAlertStatusStruct)
     {
@@ -57,19 +52,33 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(UnreadAlertStatusStruct)
     {
-        oss <<   "Category: " << m_btSpecObject.categoryID.categoryID;
+        std::string str;
 
-        oss << ", UnreadCount: ";
-        if (isUnreadCountGreater())
+        str.append("Category: ");
+        str.append(enumToString(btSpecObject.categoryID.categoryID));
+
+        str.append(", UnreadCount: ");
+        if (isUnreadCountGreater(btSpecObject))
         {
-            oss << ">" << static_cast<int>(s_max);
+            fmt::format_to(std::back_inserter(str), ">{}", UAS_MAX);
         }
         else
         {
-            oss << static_cast<int>(m_btSpecObject.unreadCount);
+            fmt::format_to(
+                std::back_inserter(str),
+                "{}",
+                btSpecObject.unreadCount
+            );
         }
+
+        return str;
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 2;
     }
 };
 

--- a/include/blevalueparser/userindex.h
+++ b/include/blevalueparser/userindex.h
@@ -27,11 +27,6 @@ public:
 private:
     BVP_CTORS(BaseValueSpec, UserIndex, UserIndexStruct)
 
-    virtual bool checkSize(size_t size) override
-    {
-        return size == 1;
-    }
-
     BVP_PARSE(UserIndexStruct)
     {
         bool result{true};
@@ -41,15 +36,19 @@ private:
         return result;
     }
 
-    virtual void toStringStream(std::ostringstream &oss) const override
+    BVP_TO_STRING(UserIndexStruct)
     {
-        if (0xFF == m_btSpecObject.userIndex)
+        if (0xFF == btSpecObject.userIndex)
         {
-            oss << "<Unknown User>";
-            return;
+            return "<Unknown User>";
         }
 
-        oss << static_cast<int>(m_btSpecObject.userIndex);
+        return fmt::format("{}", btSpecObject.userIndex);
+    }
+
+    virtual bool checkSize(size_t size) override
+    {
+        return size == 1;
     }
 };
 

--- a/tests/referencetimeinformationtest.cpp
+++ b/tests/referencetimeinformationtest.cpp
@@ -30,7 +30,7 @@ TEST_F(ReferenceTimeInformationTest, Unknown_0ms_0d_0h)
     EXPECT_EQ(0, btSpecObj.daysSinceUpdate);
     EXPECT_EQ(0, btSpecObj.hoursSinceUpdate);
 
-    EXPECT_EQ("Src: <Unknown>, Drift: 0ms, Updated: 0hours ago", result->toString());
+    EXPECT_EQ("Src: <Unknown>, Drift: 0ms, Updated: 0 hours ago", result->toString());
 }
 
 TEST_F(ReferenceTimeInformationTest, GPS_5250ms_0d_23h)
@@ -52,7 +52,7 @@ TEST_F(ReferenceTimeInformationTest, GPS_5250ms_0d_23h)
     EXPECT_EQ(0, btSpecObj.daysSinceUpdate);
     EXPECT_EQ(23, btSpecObj.hoursSinceUpdate);
 
-    EXPECT_EQ("Src: GPS, Drift: 5250ms, Updated: 23hours ago", result->toString());
+    EXPECT_EQ("Src: GPS, Drift: 5250ms, Updated: 23 hours ago", result->toString());
 }
 
 TEST_F(ReferenceTimeInformationTest, Manual_31625ms_254d_0h)
@@ -74,7 +74,7 @@ TEST_F(ReferenceTimeInformationTest, Manual_31625ms_254d_0h)
     EXPECT_EQ(254, btSpecObj.daysSinceUpdate);
     EXPECT_EQ(0, btSpecObj.hoursSinceUpdate);
 
-    EXPECT_EQ("Src: Manual, Drift: 31625ms, Updated: 254days 0hours ago", result->toString());
+    EXPECT_EQ("Src: Manual, Drift: 31625ms, Updated: 254 days 0 hours ago", result->toString());
 }
 
 TEST_F(ReferenceTimeInformationTest, CellularNetwork_Greater_254d_23h)
@@ -96,7 +96,7 @@ TEST_F(ReferenceTimeInformationTest, CellularNetwork_Greater_254d_23h)
     EXPECT_EQ(254, btSpecObj.daysSinceUpdate);
     EXPECT_EQ(23, btSpecObj.hoursSinceUpdate);
 
-    EXPECT_EQ("Src: CellularNetwork, Drift: >31625ms, Updated: 254days 23hours ago", result->toString());
+    EXPECT_EQ("Src: CellularNetwork, Drift: >31625ms, Updated: 254 days 23 hours ago", result->toString());
 }
 
 TEST_F(ReferenceTimeInformationTest, Reserved_Unknown_Greater)
@@ -120,7 +120,7 @@ TEST_F(ReferenceTimeInformationTest, Reserved_Unknown_Greater)
     EXPECT_EQ(255, btSpecObj.daysSinceUpdate);
     EXPECT_EQ(255, btSpecObj.hoursSinceUpdate);
 
-    EXPECT_EQ("Src: <Unknown>, Drift: <Unknown>, Updated: >254days ago", result->toString());
+    EXPECT_EQ("Src: <Unknown>, Drift: <Unknown>, Updated: >254 days ago", result->toString());
 }
 
 TEST_F(ReferenceTimeInformationTest, InvalidHoursSinceUpdate)
@@ -187,7 +187,7 @@ TEST_F(ReferenceTimeInformationTest, ToString)
     EXPECT_NE(nullptr, result);
     EXPECT_TRUE(result->isValid());
 
-    EXPECT_EQ("Src: NetworkTimeProtocol, Drift: 21250ms, Updated: 42days 15hours ago", result->toString());
+    EXPECT_EQ("Src: NetworkTimeProtocol, Drift: 21250ms, Updated: 42 days 15 hours ago", result->toString());
 }
 
 }  // namespace bvp


### PR DESCRIPTION
String optimization

- changed: stringstreams in internal code are replaced with string's `append()` and formatting by `fmt` library for performance purpose
- fixed: magic numbers in TimeAccuracy
- changed: added space beetwen values and full name of units ('123 days' vs '12.3kg')
- changed: hacky architecture fix for prebuilt Qt 5 on Apple Silicon replaced with cmake error with description because hack doesn't work in some cases and looks ugly; QT5_ARCH_ERROR=OFF can be used to bypass error for custom Qt 5 build

Benchmark results:

| Name                            | Before | After  | Diff(ns) | Diff(%) |
|---------------------------------|--------|--------|----------|---------|
| AlertCategoryIDBitMask          |  542ns |  354ns |    188ns |  34.69% |
| AlertCategoryID                 |  107ns | 34.5ns |   72.5ns |  67.76% |
| AlertNotificationControlPoint   |  276ns |  167ns |    109ns |  39.49% |
| BatteryCriticalStatus           |  221ns |  108ns |    113ns |  51.13% |
| BatteryEnergyStatus             | 1148ns |  389ns |    759ns |  66.11% |
| BatteryHealthInformation        |  885ns |  274ns |    611ns |  69.04% |
| BatteryHealthStatus             |  941ns |  344ns |    597ns |  63.44% |
| BatteryInformation              | 3988ns | 1851ns |   2137ns |  53.59% |
| BatteryLevelStatus              | 1041ns |  515ns |    526ns |  50.53% |
| BatteryLevel                    |  171ns | 51.7ns |  119.3ns |  69.77% |
| BatteryTimeStatus               |  505ns |  238ns |    267ns |  52.87% |
| BodyCompositionFeature          |  745ns |  416ns |    329ns |  44.16% |
| BodyCompositionMeasurementMIBFS | 1256ns |  571ns |    685ns |  54.54% |
| BodyCompositionMeasurement      | 3237ns | 1697ns |   1540ns |  47.57% |
| BodySensorLocation              |  106ns | 35.6ns |   70.4ns |  66.42% |
| CurrentTime                     | 1576ns |  484ns |   1092ns |  69.29% |
| DateTime                        |  564ns |  236ns |    328ns |  58.16% |
| DateUTC                         |  843ns |  553ns |    290ns |  34.40% |
| DayDateTime                     |  923ns |  318ns |    605ns |  65.55% |
| DayOfWeek                       |  104ns | 33.4ns |   70.6ns |  67.88% |
| DSTOffset                       |  109ns | 37.2ns |   71.8ns |  65.87% |
| EstimatedServiceDate            | 1103ns |  555ns |    548ns |  49.68% |
| ExactTime256                    | 1202ns |  394ns |    808ns |  67.22% |
| HeartRateControlPoint           |  109ns | 36.6ns |   72.4ns |  66.42% |
| HeartRateMeasurement            | 1043ns |  517ns |    526ns |  50.43% |
| HexString/1                     |  143ns | 49.5ns |   93.5ns |  65.38% |
| HexString/8                     |  248ns |   98ns |    150ns |  60.48% |
| HexString/64                    |  537ns |  195ns |    342ns |  63.69% |
| HexString/512                   | 1920ns |  975ns |    945ns |  49.22% |
| LocalTimeInformation            |  668ns |  155ns |    513ns |  76.80% |
| NewAlert                        |  374ns |  199ns |    175ns |  46.79% |
| PnPID                           |  662ns |  363ns |    299ns |  45.17% |
| ReferenceTimeInformation        |  798ns |  247ns |    551ns |  69.05% |
| SupportedNewAlertCategory       |  893ns |  391ns |    502ns |  56.22% |
| SupportedUnreadAlertCategory    |  890ns |  391ns |    499ns |  56.07% |
| TextString/1                    |   99ns | 25.4ns |   73.6ns |  74.34% |
| TextString/8                    |  107ns | 25.8ns |   81.2ns |  75.89% |
| TextString/64                   |  233ns | 64.9ns |  168.1ns |  72.15% |
| TextString/512                  |  600ns |  137ns |    463ns |  77.17% |
| TimeAccuracy                    |  178ns | 50.2ns |  127.8ns |  71.80% |
| TimeSource                      |  110ns | 37.6ns |   72.4ns |  65.82% |
| TimeZone                        |  154ns | 33.9ns |  120.1ns |  77.99% |
| UnreadAlertStatus               |  271ns |  123ns |    148ns |  54.61% |
| UserIndex                       |  154ns | 32.9ns |  121.1ns |  78.64% |